### PR TITLE
[Feat/#34] 비밀번호 변경 페이지 구현

### DIFF
--- a/frontend/lib/screens/changePW_screen.dart
+++ b/frontend/lib/screens/changePW_screen.dart
@@ -1,22 +1,25 @@
 import 'package:flutter/material.dart';
 
-class changePWPage extends StatefulWidget {
-  const changePWPage({super.key});
+class ChangePWPage extends StatefulWidget {
+  const ChangePWPage({super.key});
 
   @override
-  State<changePWPage> createState() => _changePWPageState();
+  State<ChangePWPage> createState() => _ChangePWPageState();
 }
 
-class _changePWPageState extends State<changePWPage> {
+class _ChangePWPageState extends State<ChangePWPage> {
+  final TextEditingController newController = TextEditingController();
+  final TextEditingController checkController = TextEditingController();
+
+  String presentPW = 'alsxorrl1205!';
+  bool isVisible1 = false;
+  bool isVisible2 = false;
+  bool isVisible3 = false;
+
+  final formKey = GlobalKey<FormState>();
+
   @override
   Widget build(BuildContext context) {
-    TextEditingController newController = TextEditingController();
-    TextEditingController checkController = TextEditingController();
-
-    String presentPW = 'alsxorrl1205!';
-
-    final formKey = GlobalKey<FormState>();
-
     return Scaffold(
       backgroundColor: Colors.white,
       appBar: AppBar(
@@ -73,7 +76,7 @@ class _changePWPageState extends State<changePWPage> {
               // 비밀번호 입력 필드
               TextFormField(
                 controller: newController,
-                obscureText: true,
+                obscureText: !isVisible1, // !isVisible1 = false
                 style: const TextStyle(height: 1.5),
                 decoration: InputDecoration(
                   filled: true,
@@ -82,7 +85,15 @@ class _changePWPageState extends State<changePWPage> {
                     borderRadius: BorderRadius.circular(5.0),
                     borderSide: BorderSide.none,
                   ),
-                  suffixIcon: const Icon(Icons.visibility),
+                  suffixIcon: IconButton(
+                    onPressed: () {
+                      setState(() {
+                        isVisible1 = !isVisible1;
+                      });
+                    },
+                    icon: Icon(
+                        isVisible1 ? Icons.visibility_off : Icons.visibility),
+                  ),
                   suffixIconColor: const Color(0xFF848488),
                   contentPadding: const EdgeInsets.symmetric(
                       horizontal: 10.0, vertical: 5.0),
@@ -104,10 +115,10 @@ class _changePWPageState extends State<changePWPage> {
               ),
               const SizedBox(height: 10),
 
-              // 비밀번호 확인 핃드
+              // 비밀번호 확인 필드
               TextFormField(
                 controller: checkController,
-                obscureText: true,
+                obscureText: !isVisible2,
                 style: const TextStyle(height: 1.5),
                 decoration: InputDecoration(
                   filled: true,
@@ -116,15 +127,26 @@ class _changePWPageState extends State<changePWPage> {
                     borderRadius: BorderRadius.circular(5.0),
                     borderSide: BorderSide.none,
                   ),
-                  suffixIcon: const Icon(Icons.visibility),
+                  suffixIcon: IconButton(
+                    onPressed: () {
+                      setState(() {
+                        isVisible2 = !isVisible2;
+                      });
+                    },
+                    icon: Icon(
+                        isVisible2 ? Icons.visibility_off : Icons.visibility),
+                  ),
                   suffixIconColor: const Color(0xFF848488),
                   contentPadding: const EdgeInsets.symmetric(
                       horizontal: 10.0, vertical: 5.0),
                 ),
                 validator: (value) {
-                  // 새 비밀번호에서 작성한 비밀번호와 같지 않다면 에러 메세지 표시
-                  if (checkController.text != newController.text) {
-                    return '다시 입력해주세요';
+                  // 새 비밀번호에서 작성한 비밀번호와 같지 않다면 에러 메시지 표시
+                  if (value == null || value.isEmpty) {
+                    return '비밀번호를 다시 입력하세요';
+                  }
+                  if (value != newController.text) {
+                    return '비밀번호가 일치하지 않습니다';
                   }
                   return null;
                 },
@@ -143,7 +165,7 @@ class _changePWPageState extends State<changePWPage> {
 
               // 현재 비밀번호 입력 필드
               TextFormField(
-                obscureText: true,
+                obscureText: !isVisible3,
                 initialValue: presentPW,
                 readOnly: true, // 읽기 전용
                 style: const TextStyle(height: 1.5),
@@ -154,7 +176,15 @@ class _changePWPageState extends State<changePWPage> {
                     borderRadius: BorderRadius.circular(5.0),
                     borderSide: BorderSide.none,
                   ),
-                  suffixIcon: const Icon(Icons.visibility),
+                  suffixIcon: IconButton(
+                    onPressed: () {
+                      setState(() {
+                        isVisible3 = !isVisible3;
+                      });
+                    },
+                    icon: Icon(
+                        isVisible3 ? Icons.visibility_off : Icons.visibility),
+                  ),
                   suffixIconColor: const Color(0xFF848488),
                   contentPadding: const EdgeInsets.symmetric(
                       horizontal: 10.0, vertical: 5.0),
@@ -165,7 +195,14 @@ class _changePWPageState extends State<changePWPage> {
               // 비밀번호 변경 버튼
               Center(
                 child: ElevatedButton(
-                  onPressed: () {},
+                  onPressed: () {
+                    // 유효성 검사가 완료될 시 변경 다이얼로그 표시
+                    if (formKey.currentState?.validate() ?? false) {
+                      changePWDialog(context);
+
+                      Navigator.pop(context);
+                    }
+                  },
                   style: ElevatedButton.styleFrom(
                     backgroundColor: const Color(0xFF2A72E7),
                     shape: RoundedRectangleBorder(
@@ -187,6 +224,72 @@ class _changePWPageState extends State<changePWPage> {
           ),
         ),
       ),
+    );
+  }
+
+  // 비밀번호 변경 다이엉로그
+  Future<dynamic> changePWDialog(BuildContext context) {
+    return showDialog(
+      context: context,
+      barrierDismissible: true,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          backgroundColor: Colors.white,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(20.0),
+          ),
+          icon: const Icon(
+            Icons.question_mark_rounded,
+            size: 40,
+            color: Color(0xFF2A72E7),
+          ),
+          // 메인 타이틀
+          title: const Column(
+            children: [
+              Text("이대로 변경하시겠습니까?"),
+            ],
+          ),
+          actions: [
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                TextButton(
+                  onPressed: () {
+                    Navigator.pop(context);
+                  },
+                  style: TextButton.styleFrom(
+                    fixedSize: const Size(100, 20),
+                  ),
+                  child: const Text(
+                    '닫기',
+                    style: TextStyle(
+                      fontWeight: FontWeight.bold,
+                      fontSize: 16,
+                      color: Color(0xFF2A72E7),
+                    ),
+                  ),
+                ),
+                TextButton(
+                  onPressed: () {
+                    Navigator.pop(context);
+                  },
+                  style: TextButton.styleFrom(
+                    fixedSize: const Size(100, 20),
+                  ),
+                  child: const Text(
+                    '변경',
+                    style: TextStyle(
+                      fontWeight: FontWeight.bold,
+                      fontSize: 16,
+                      color: Color(0xFF2A72E7),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        );
+      },
     );
   }
 }

--- a/frontend/lib/screens/changePW_screen.dart
+++ b/frontend/lib/screens/changePW_screen.dart
@@ -1,12 +1,21 @@
 import 'package:flutter/material.dart';
 
-class changePWPage extends StatelessWidget {
+class changePWPage extends StatefulWidget {
   const changePWPage({super.key});
 
   @override
+  State<changePWPage> createState() => _changePWPageState();
+}
+
+class _changePWPageState extends State<changePWPage> {
+  @override
   Widget build(BuildContext context) {
     TextEditingController newController = TextEditingController();
-    TextEditingController presentController = TextEditingController();
+    TextEditingController checkController = TextEditingController();
+
+    String presentPW = 'alsxorrl1205!';
+
+    final formKey = GlobalKey<FormState>();
 
     return Scaffold(
       backgroundColor: Colors.white,
@@ -38,32 +47,34 @@ class changePWPage extends StatelessWidget {
       ),
       body: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 24.0, vertical: 25.0),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            const Text(
-              '비밀번호 변경',
-              style: TextStyle(
-                fontSize: 20,
-                fontWeight: FontWeight.bold,
+        child: Form(
+          key: formKey,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const Text(
+                '비밀번호 변경',
+                style: TextStyle(
+                  fontSize: 20,
+                  fontWeight: FontWeight.bold,
+                ),
               ),
-            ),
-            const SizedBox(height: 20),
-            const Text(
-              '새 비밀번호',
-              style: TextStyle(
-                fontSize: 16,
-                fontWeight: FontWeight.bold,
-                color: Color(0xFF848488),
+              const SizedBox(height: 20),
+              const Text(
+                '새 비밀번호',
+                style: TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.bold,
+                  color: Color(0xFF848488),
+                ),
               ),
-            ),
-            const SizedBox(height: 7),
-            SizedBox(
-              height: 35,
-              child: TextFormField(
+              const SizedBox(height: 7),
+
+              // 비밀번호 입력 필드
+              TextFormField(
                 controller: newController,
                 obscureText: true,
-                style: const TextStyle(height: 1.0),
+                style: const TextStyle(height: 1.5),
                 decoration: InputDecoration(
                   filled: true,
                   fillColor: const Color(0xFFEFEFF2),
@@ -73,16 +84,31 @@ class changePWPage extends StatelessWidget {
                   ),
                   suffixIcon: const Icon(Icons.visibility),
                   suffixIconColor: const Color(0xFF848488),
+                  contentPadding: const EdgeInsets.symmetric(
+                      horizontal: 10.0, vertical: 5.0),
                 ),
+                validator: (value) {
+                  if (value == null || value.isEmpty) {
+                    return '비밀번호를 입력하세요';
+                  }
+                  if (value.length > 20) {
+                    return '20자 이하로 작성해주세요';
+                  }
+                  if (!RegExp(r'^(?=.*[a-zA-Z])(?=.*[!@#\$&*~]).{1,}$')
+                      .hasMatch(value)) {
+                    return '영문자와 특수문자가 포함되어야 합니다';
+                  }
+                  return null;
+                },
+                autovalidateMode: AutovalidateMode.onUserInteraction,
               ),
-            ),
-            const SizedBox(height: 6),
-            SizedBox(
-              height: 35,
-              child: TextFormField(
-                controller: newController,
+              const SizedBox(height: 10),
+
+              // 비밀번호 확인 핃드
+              TextFormField(
+                controller: checkController,
                 obscureText: true,
-                style: const TextStyle(height: 1.0),
+                style: const TextStyle(height: 1.5),
                 decoration: InputDecoration(
                   filled: true,
                   fillColor: const Color(0xFFEFEFF2),
@@ -92,25 +118,35 @@ class changePWPage extends StatelessWidget {
                   ),
                   suffixIcon: const Icon(Icons.visibility),
                   suffixIconColor: const Color(0xFF848488),
+                  contentPadding: const EdgeInsets.symmetric(
+                      horizontal: 10.0, vertical: 5.0),
+                ),
+                validator: (value) {
+                  // 새 비밀번호에서 작성한 비밀번호와 같지 않다면 에러 메세지 표시
+                  if (checkController.text != newController.text) {
+                    return '다시 입력해주세요';
+                  }
+                  return null;
+                },
+                autovalidateMode: AutovalidateMode.onUserInteraction,
+              ),
+              const SizedBox(height: 35),
+              const Text(
+                '현재 비밀번호',
+                style: TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.bold,
+                  color: Color(0xFF848488),
                 ),
               ),
-            ),
-            const SizedBox(height: 35),
-            const Text(
-              '현재 비밀번호',
-              style: TextStyle(
-                fontSize: 16,
-                fontWeight: FontWeight.bold,
-                color: Color(0xFF848488),
-              ),
-            ),
-            const SizedBox(height: 7),
-            SizedBox(
-              height: 35,
-              child: TextFormField(
+              const SizedBox(height: 7),
+
+              // 현재 비밀번호 입력 필드
+              TextFormField(
                 obscureText: true,
-                controller: presentController,
-                style: const TextStyle(height: 1.0),
+                initialValue: presentPW,
+                readOnly: true, // 읽기 전용
+                style: const TextStyle(height: 1.5),
                 decoration: InputDecoration(
                   filled: true,
                   fillColor: const Color(0xFFEFEFF2),
@@ -120,31 +156,35 @@ class changePWPage extends StatelessWidget {
                   ),
                   suffixIcon: const Icon(Icons.visibility),
                   suffixIconColor: const Color(0xFF848488),
+                  contentPadding: const EdgeInsets.symmetric(
+                      horizontal: 10.0, vertical: 5.0),
                 ),
               ),
-            ),
-            const SizedBox(height: 68),
-            Center(
-              child: ElevatedButton(
-                onPressed: () {},
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: const Color(0xFF2A72E7),
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(10.0),
+              const SizedBox(height: 68),
+
+              // 비밀번호 변경 버튼
+              Center(
+                child: ElevatedButton(
+                  onPressed: () {},
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: const Color(0xFF2A72E7),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(10.0),
+                    ),
+                    fixedSize: const Size(300, 40),
                   ),
-                  fixedSize: const Size(300, 40),
-                ),
-                child: const Text(
-                  '비밀번호 변경',
-                  style: TextStyle(
-                    fontSize: 15,
-                    fontWeight: FontWeight.bold,
-                    color: Colors.white,
+                  child: const Text(
+                    '비밀번호 변경',
+                    style: TextStyle(
+                      fontSize: 15,
+                      fontWeight: FontWeight.bold,
+                      color: Colors.white,
+                    ),
                   ),
                 ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/frontend/lib/screens/changePW_screen.dart
+++ b/frontend/lib/screens/changePW_screen.dart
@@ -1,0 +1,152 @@
+import 'package:flutter/material.dart';
+
+class changePWPage extends StatelessWidget {
+  const changePWPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    TextEditingController newController = TextEditingController();
+    TextEditingController presentController = TextEditingController();
+
+    return Scaffold(
+      backgroundColor: Colors.white,
+      appBar: AppBar(
+        toolbarHeight: 70,
+        leading: BackButton(
+          onPressed: () {
+            Navigator.pop(context);
+          },
+        ),
+        actions: const [
+          Padding(
+            padding: EdgeInsets.only(right: 23.0),
+            child: Icon(
+              Icons.add_alert,
+              size: 30,
+              color: Colors.black,
+            ),
+          ),
+          Padding(
+            padding: EdgeInsets.only(right: 23.0),
+            child: Icon(
+              Icons.account_circle,
+              size: 30,
+              color: Colors.black,
+            ),
+          ),
+        ],
+      ),
+      body: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 24.0, vertical: 25.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text(
+              '비밀번호 변경',
+              style: TextStyle(
+                fontSize: 20,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            const SizedBox(height: 20),
+            const Text(
+              '새 비밀번호',
+              style: TextStyle(
+                fontSize: 16,
+                fontWeight: FontWeight.bold,
+                color: Color(0xFF848488),
+              ),
+            ),
+            const SizedBox(height: 7),
+            SizedBox(
+              height: 35,
+              child: TextFormField(
+                controller: newController,
+                obscureText: true,
+                style: const TextStyle(height: 1.0),
+                decoration: InputDecoration(
+                  filled: true,
+                  fillColor: const Color(0xFFEFEFF2),
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(5.0),
+                    borderSide: BorderSide.none,
+                  ),
+                  suffixIcon: const Icon(Icons.visibility),
+                  suffixIconColor: const Color(0xFF848488),
+                ),
+              ),
+            ),
+            const SizedBox(height: 6),
+            SizedBox(
+              height: 35,
+              child: TextFormField(
+                controller: newController,
+                obscureText: true,
+                style: const TextStyle(height: 1.0),
+                decoration: InputDecoration(
+                  filled: true,
+                  fillColor: const Color(0xFFEFEFF2),
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(5.0),
+                    borderSide: BorderSide.none,
+                  ),
+                  suffixIcon: const Icon(Icons.visibility),
+                  suffixIconColor: const Color(0xFF848488),
+                ),
+              ),
+            ),
+            const SizedBox(height: 35),
+            const Text(
+              '현재 비밀번호',
+              style: TextStyle(
+                fontSize: 16,
+                fontWeight: FontWeight.bold,
+                color: Color(0xFF848488),
+              ),
+            ),
+            const SizedBox(height: 7),
+            SizedBox(
+              height: 35,
+              child: TextFormField(
+                obscureText: true,
+                controller: presentController,
+                style: const TextStyle(height: 1.0),
+                decoration: InputDecoration(
+                  filled: true,
+                  fillColor: const Color(0xFFEFEFF2),
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(5.0),
+                    borderSide: BorderSide.none,
+                  ),
+                  suffixIcon: const Icon(Icons.visibility),
+                  suffixIconColor: const Color(0xFF848488),
+                ),
+              ),
+            ),
+            const SizedBox(height: 68),
+            Center(
+              child: ElevatedButton(
+                onPressed: () {},
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: const Color(0xFF2A72E7),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(10.0),
+                  ),
+                  fixedSize: const Size(300, 40),
+                ),
+                child: const Text(
+                  '비밀번호 변경',
+                  style: TextStyle(
+                    fontSize: 15,
+                    fontWeight: FontWeight.bold,
+                    color: Colors.white,
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/lib/screens/home_screen.dart
+++ b/frontend/lib/screens/home_screen.dart
@@ -199,6 +199,7 @@ class _HomePageState extends State<HomePage> {
             const Padding(
               padding: EdgeInsets.only(right: 20.0),
               child: Icon(
+                // badge 패키지 사용해서 다시 작성 예정
                 Icons.add_alert,
                 size: 30,
                 color: Colors.black,


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
#34

## ✨ 코드 변경 내용
<!-- 코드 변경에 대한 설명을 적어주세요 -->
### 비밀번호 변경 페이지 UI 구현
- TextFormField로 구현
### 비밀번호 유효성 검사
- 새 비밀번호 입력 시 길이, 영문자, 툭수문자 유효성 검사
- 새 비밀번호 확인 입력 시 새 비밀번호와 동일한지 검사
### 비밀번호 보임/숨김 및 비밀번호 변경 버튼 onPressed 구현
- 유효성 검사가 완료될 시 다이얼로그 표시 및 이전 페이지로 이동이 가능하게 구현

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->
![Simulator Screenshot - iPhone 14 Pro Max(배달반도) - 2024-06-19 at 10 44 52](https://github.com/Jeong-Reminder/reminder-frontend/assets/127868094/b78aefc8-11fc-4e29-8ab5-dae99b02bab2)

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
TextFormField에 Sizedbox를 씌우지 않아야 에러메시지가 띄워질 때 TextFormField 높이 영향없이 띄울 수 있다.