### PR TITLE
[Feat/#44] 프로필 설정하기 페이지 구현

### DIFF
--- a/frontend/ios/Podfile.lock
+++ b/frontend/ios/Podfile.lock
@@ -14,7 +14,7 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/image_picker_ios/ios"
 
 SPEC CHECKSUMS:
-  Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
+  Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
   image_picker_ios: 99dfe1854b4fa34d0364e74a78448a0151025425
 
 PODFILE CHECKSUM: c4c93c5f6502fe2754f48404d3594bf779584011

--- a/frontend/ios/Runner.xcodeproj/project.pbxproj
+++ b/frontend/ios/Runner.xcodeproj/project.pbxproj
@@ -205,7 +205,7 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
-				LastUpgradeCheck = 1510;
+				LastUpgradeCheck = 1430;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					331C8080294A63A400263BE5 = {

--- a/frontend/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/frontend/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1510"
+   LastUpgradeVersion = "1430"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/frontend/ios/Runner/Info.plist
+++ b/frontend/ios/Runner/Info.plist
@@ -46,8 +46,10 @@
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
 	<key>NSCameraUsageDescription</key>
-	<string>your usage description here</string>
+	<string>Used to demonstrate image picker plugin</string>
 	<key>NSMicrophoneUsageDescription</key>
-	<string>your usage description here</string>
+	<string>Used to capture audio for image picker plugin</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>Used to demonstrate image picker plugin</string>
 </dict>
 </plist>

--- a/frontend/lib/screens/profileSetting_screen.dart
+++ b/frontend/lib/screens/profileSetting_screen.dart
@@ -1,0 +1,135 @@
+import 'package:flutter/material.dart';
+
+class ProfileSettingPage extends StatefulWidget {
+  const ProfileSettingPage({super.key});
+
+  @override
+  State<ProfileSettingPage> createState() => _ProfileSettingPageState();
+}
+
+class _ProfileSettingPageState extends State<ProfileSettingPage> {
+  @override
+  Widget build(BuildContext context) {
+    final imageSize = MediaQuery.of(context).size.width / 4; // 전체 화면 너비의 4분의 1
+
+    return Scaffold(
+      body: Padding(
+        padding: const EdgeInsets.only(top: 200),
+        child: Center(
+          child: Column(
+            children: [
+              const Text(
+                '프로필 설정',
+                style: TextStyle(
+                  fontSize: 20,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              const SizedBox(height: 14),
+              const Text(
+                '나중에 언제든지 변경할 수 있습니다',
+                style: TextStyle(
+                  fontSize: 16,
+                  color: Color(0xFF808080),
+                ),
+              ),
+              const SizedBox(height: 45),
+
+              // 프로필
+              IconButton(
+                onPressed: () {
+                  showModalBottomSheet(
+                    context: context,
+                    shape: const RoundedRectangleBorder(
+                      borderRadius: BorderRadius.vertical(
+                        top: Radius.circular(25),
+                      ),
+                    ),
+                    backgroundColor: Colors.white,
+                    builder: (context) {
+                      return Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          // 카메라 버튼
+                          TextButton.icon(
+                            onPressed: () {},
+                            style: TextButton.styleFrom(
+                              minimumSize: const Size(double.infinity, 80),
+                              shape: RoundedRectangleBorder(
+                                  borderRadius: BorderRadius.circular(0.0)),
+                            ),
+                            icon: const Icon(
+                              Icons.camera_alt,
+                              color: Colors.black,
+                            ),
+                            label: const Text(
+                              '카메라',
+                              style: TextStyle(
+                                fontSize: 18,
+                                color: Colors.black,
+                              ),
+                            ),
+                          ),
+                          const Divider(
+                            thickness: 3,
+                          ),
+
+                          // 라이브러리 버튼
+                          TextButton.icon(
+                            onPressed: () {},
+                            style: TextButton.styleFrom(
+                                minimumSize: const Size(double.infinity, 80),
+                                shape: RoundedRectangleBorder(
+                                    borderRadius: BorderRadius.circular(0.0))),
+                            icon: const Icon(
+                              Icons.photo_album_outlined,
+                              color: Colors.black,
+                            ),
+                            label: const Text(
+                              '라이브러리에서 불러오기',
+                              style: TextStyle(
+                                fontSize: 18,
+                                color: Colors.black,
+                              ),
+                            ),
+                          ),
+                        ],
+                      );
+                    },
+                  );
+                },
+                icon: Icon(
+                  Icons.account_circle,
+                  size: imageSize,
+                ),
+              ),
+              const SizedBox(height: 74),
+
+              // 알리미 시작하기 버튼
+              ElevatedButton(
+                onPressed: () {
+                  // 이미지 설정해야만 이동
+                },
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: const Color(0xFFDBE7FB),
+                  minimumSize: const Size(211, 40),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(5.0),
+                  ),
+                ),
+                child: const Text(
+                  '알리미 시작하기',
+                  style: TextStyle(
+                    fontSize: 14,
+                    fontWeight: FontWeight.bold,
+                    color: Colors.black,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/lib/screens/profileSetting_screen.dart
+++ b/frontend/lib/screens/profileSetting_screen.dart
@@ -52,146 +52,119 @@ class _ProfileSettingPageState extends State<ProfileSettingPage> {
     return Scaffold(
       body: Padding(
         padding: const EdgeInsets.only(top: 200),
-        child: Center(
-          child: Column(
-            children: [
-              const Text(
-                '프로필 설정',
-                style: TextStyle(
-                  fontSize: 20,
-                  fontWeight: FontWeight.bold,
-                ),
-              ),
-              const SizedBox(height: 14),
-              const Text(
-                '나중에 언제든지 변경할 수 있습니다',
-                style: TextStyle(
-                  fontSize: 16,
-                  color: Color(0xFF808080),
-                ),
-              ),
-              const SizedBox(height: 45),
-
-              // 프로필
-              if (pickedImage == null)
-                IconButton(
-                  onPressed: () {
-                    wayToChooseImage(context);
-                  },
-                  icon: Icon(
-                    Icons.account_circle,
-                    size: imageSize,
-                  ),
-                )
-              else
-                Container(
-                  width: imageSize,
-                  height: imageSize,
-                  decoration: BoxDecoration(
-                    shape: BoxShape.circle,
-                    border: Border.all(
-                        color: Theme.of(context).colorScheme.primary, width: 2),
-                    image: DecorationImage(
-                      image: FileImage(
-                        File(pickedImage!.path),
-                      ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.end,
+          children: [
+            Center(
+              child: Column(
+                children: [
+                  const Text(
+                    '프로필 설정',
+                    style: TextStyle(
+                      fontSize: 20,
+                      fontWeight: FontWeight.bold,
                     ),
                   ),
-                ),
-              const SizedBox(height: 74),
-
-              // 알리미 시작하기 버튼
-              ElevatedButton(
-                onPressed: () {
-                  // 이미지 설정해야만 이동
-                },
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: const Color(0xFFDBE7FB),
-                  minimumSize: const Size(211, 40),
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(5.0),
+                  const SizedBox(height: 14),
+                  const Text(
+                    '나중에 언제든지 변경할 수 있습니다',
+                    style: TextStyle(
+                      fontSize: 16,
+                      color: Color(0xFF808080),
+                    ),
                   ),
-                ),
-                child: const Text(
-                  '알리미 시작하기',
-                  style: TextStyle(
-                    fontSize: 14,
-                    fontWeight: FontWeight.bold,
+                  const SizedBox(height: 45),
+
+                  // 프로필
+                  if (pickedImage == null)
+                    Icon(
+                      Icons.account_circle,
+                      size: imageSize,
+                    )
+                  else
+                    Container(
+                      width: imageSize,
+                      height: imageSize,
+                      decoration: BoxDecoration(
+                        shape: BoxShape.circle,
+                        border: Border.all(
+                            color: Theme.of(context).colorScheme.primary,
+                            width: 2),
+                        image: DecorationImage(
+                          image: FileImage(
+                            File(pickedImage!.path),
+                          ),
+                        ),
+                      ),
+                    ),
+                  const SizedBox(height: 74),
+
+                  // 카메라와 갤러리 연동 버튼
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      getImageButton(() {
+                        getCameraImage();
+                      }, Icons.camera_alt_rounded),
+                      const SizedBox(width: 50),
+                      getImageButton(() {
+                        getGalleryImage();
+                      }, Icons.photo_album_outlined),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 70),
+
+            // 알리미 시작하기 버튼
+            GestureDetector(
+              onTap: () {
+                // 프로필 설정해야만 이동
+                // 설정을 안하고 이동할 시 프로필을 설정하세요라고 입력
+              },
+              child: const Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    '알리미 시작하기',
+                    style: TextStyle(
+                      fontSize: 14,
+                      fontWeight: FontWeight.bold,
+                      color: Colors.black,
+                    ),
+                  ),
+                  SizedBox(width: 8), // 텍스트와 아이콘 사이의 간격
+                  Icon(
+                    Icons.chevron_right_sharp,
+                    size: 40.0,
                     color: Colors.black,
                   ),
-                ),
+                ],
               ),
-            ],
-          ),
+            ),
+          ],
         ),
       ),
     );
   }
 
-  // 이미지 선택 함수
-  Future<dynamic> wayToChooseImage(BuildContext context) {
-    return showModalBottomSheet(
-      context: context,
-      shape: const RoundedRectangleBorder(
-        borderRadius: BorderRadius.vertical(
-          top: Radius.circular(25),
+  // 카메라 / 갤러리 연동 버튼 함수
+  Widget getImageButton(VoidCallback getImage, IconData icon) {
+    return ElevatedButton(
+      onPressed: getImage,
+      style: ElevatedButton.styleFrom(
+        backgroundColor: const Color(0xFFDBE7FB),
+        minimumSize: const Size(20, 60),
+        elevation: 3.0,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(10.0),
         ),
       ),
-      // backgroundColor: Colors.white,
-      builder: (context) {
-        return Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            // 카메라 버튼
-            TextButton.icon(
-              onPressed: () {
-                getCameraImage();
-              },
-              style: TextButton.styleFrom(
-                minimumSize: const Size(double.infinity, 80),
-                shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(0.0)),
-              ),
-              icon: const Icon(
-                Icons.camera_alt,
-                color: Colors.black,
-              ),
-              label: const Text(
-                '카메라',
-                style: TextStyle(
-                  fontSize: 18,
-                  color: Colors.black,
-                ),
-              ),
-            ),
-            const Divider(
-              thickness: 3,
-            ),
-
-            // 라이브러리 버튼
-            TextButton.icon(
-              onPressed: () {
-                getGalleryImage();
-              },
-              style: TextButton.styleFrom(
-                  minimumSize: const Size(double.infinity, 80),
-                  shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(0.0))),
-              icon: const Icon(
-                Icons.photo_album_outlined,
-                color: Colors.black,
-              ),
-              label: const Text(
-                '갤러리',
-                style: TextStyle(
-                  fontSize: 18,
-                  color: Colors.black,
-                ),
-              ),
-            ),
-          ],
-        );
-      },
+      child: Icon(
+        icon,
+        color: Colors.white,
+      ),
     );
   }
 }

--- a/frontend/lib/screens/profileSetting_screen.dart
+++ b/frontend/lib/screens/profileSetting_screen.dart
@@ -151,9 +151,9 @@ class _ProfileSettingPageState extends State<ProfileSettingPage> {
                 mainAxisSize: MainAxisSize.min,
                 children: [
                   Text(
-                    '알리미 시작하기',
+                    '기술 스택 지정하기',
                     style: TextStyle(
-                      fontSize: 14,
+                      fontSize: 16,
                       fontWeight: FontWeight.bold,
                       color: Colors.black,
                     ),

--- a/frontend/lib/screens/profileSetting_screen.dart
+++ b/frontend/lib/screens/profileSetting_screen.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:frontend/screens/home_screen.dart';
 import 'package:image_picker/image_picker.dart';
 
 class ProfileSettingPage extends StatefulWidget {
@@ -121,7 +122,30 @@ class _ProfileSettingPageState extends State<ProfileSettingPage> {
             GestureDetector(
               onTap: () {
                 // 프로필 설정해야만 이동
-                // 설정을 안하고 이동할 시 프로필을 설정하세요라고 입력
+                // 설정을 안하고 이동할 시 "프로필을 설정하세요"라고 출력
+                if (pickedImage != null) {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (context) => const HomePage(),
+                    ),
+                  );
+                } else {
+                  // 하단 스낵바
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(
+                      backgroundColor: Color(0xFF2A72E7),
+                      content: Center(
+                        child: Text(
+                          '프로필을 지정해주세요',
+                          style: TextStyle(
+                            fontSize: 16,
+                          ),
+                        ),
+                      ),
+                    ),
+                  );
+                }
               },
               child: const Row(
                 mainAxisSize: MainAxisSize.min,

--- a/frontend/lib/screens/profileSetting_screen.dart
+++ b/frontend/lib/screens/profileSetting_screen.dart
@@ -1,4 +1,8 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:image_picker/image_picker.dart';
 
 class ProfileSettingPage extends StatefulWidget {
   const ProfileSettingPage({super.key});
@@ -8,6 +12,39 @@ class ProfileSettingPage extends StatefulWidget {
 }
 
 class _ProfileSettingPageState extends State<ProfileSettingPage> {
+  // build 메서드 안에 선언을 하면 상태가 변경될 때마다 변수가 초기화되기 때문에 null 체크가 항상 true로 평가되서 build 메서드 밖에서 정의
+  XFile? pickedImage; // 파일 받을 변수
+
+  // 카메라 연동 함수
+  void getCameraImage() async {
+    final pickedCamera =
+        await ImagePicker().pickImage(source: ImageSource.camera);
+    if (pickedCamera != null) {
+      setState(() {
+        pickedImage = pickedCamera;
+      });
+    } else {
+      if (kDebugMode) {
+        print('이미지 선택안함');
+      }
+    }
+  }
+
+  // 갤러리 연동 함수
+  void getGalleryImage() async {
+    final pickedGallery =
+        await ImagePicker().pickImage(source: ImageSource.gallery);
+    if (pickedGallery != null) {
+      setState(() {
+        pickedImage = pickedGallery;
+      });
+    } else {
+      if (kDebugMode) {
+        print('이미지 선택안함');
+      }
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final imageSize = MediaQuery.of(context).size.width / 4; // 전체 화면 너비의 4분의 1
@@ -36,73 +73,31 @@ class _ProfileSettingPageState extends State<ProfileSettingPage> {
               const SizedBox(height: 45),
 
               // 프로필
-              IconButton(
-                onPressed: () {
-                  showModalBottomSheet(
-                    context: context,
-                    shape: const RoundedRectangleBorder(
-                      borderRadius: BorderRadius.vertical(
-                        top: Radius.circular(25),
+              if (pickedImage == null)
+                IconButton(
+                  onPressed: () {
+                    wayToChooseImage(context);
+                  },
+                  icon: Icon(
+                    Icons.account_circle,
+                    size: imageSize,
+                  ),
+                )
+              else
+                Container(
+                  width: imageSize,
+                  height: imageSize,
+                  decoration: BoxDecoration(
+                    shape: BoxShape.circle,
+                    border: Border.all(
+                        color: Theme.of(context).colorScheme.primary, width: 2),
+                    image: DecorationImage(
+                      image: FileImage(
+                        File(pickedImage!.path),
                       ),
                     ),
-                    backgroundColor: Colors.white,
-                    builder: (context) {
-                      return Column(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          // 카메라 버튼
-                          TextButton.icon(
-                            onPressed: () {},
-                            style: TextButton.styleFrom(
-                              minimumSize: const Size(double.infinity, 80),
-                              shape: RoundedRectangleBorder(
-                                  borderRadius: BorderRadius.circular(0.0)),
-                            ),
-                            icon: const Icon(
-                              Icons.camera_alt,
-                              color: Colors.black,
-                            ),
-                            label: const Text(
-                              '카메라',
-                              style: TextStyle(
-                                fontSize: 18,
-                                color: Colors.black,
-                              ),
-                            ),
-                          ),
-                          const Divider(
-                            thickness: 3,
-                          ),
-
-                          // 라이브러리 버튼
-                          TextButton.icon(
-                            onPressed: () {},
-                            style: TextButton.styleFrom(
-                                minimumSize: const Size(double.infinity, 80),
-                                shape: RoundedRectangleBorder(
-                                    borderRadius: BorderRadius.circular(0.0))),
-                            icon: const Icon(
-                              Icons.photo_album_outlined,
-                              color: Colors.black,
-                            ),
-                            label: const Text(
-                              '라이브러리에서 불러오기',
-                              style: TextStyle(
-                                fontSize: 18,
-                                color: Colors.black,
-                              ),
-                            ),
-                          ),
-                        ],
-                      );
-                    },
-                  );
-                },
-                icon: Icon(
-                  Icons.account_circle,
-                  size: imageSize,
+                  ),
                 ),
-              ),
               const SizedBox(height: 74),
 
               // 알리미 시작하기 버튼
@@ -130,6 +125,73 @@ class _ProfileSettingPageState extends State<ProfileSettingPage> {
           ),
         ),
       ),
+    );
+  }
+
+  // 이미지 선택 함수
+  Future<dynamic> wayToChooseImage(BuildContext context) {
+    return showModalBottomSheet(
+      context: context,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(
+          top: Radius.circular(25),
+        ),
+      ),
+      // backgroundColor: Colors.white,
+      builder: (context) {
+        return Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            // 카메라 버튼
+            TextButton.icon(
+              onPressed: () {
+                getCameraImage();
+              },
+              style: TextButton.styleFrom(
+                minimumSize: const Size(double.infinity, 80),
+                shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(0.0)),
+              ),
+              icon: const Icon(
+                Icons.camera_alt,
+                color: Colors.black,
+              ),
+              label: const Text(
+                '카메라',
+                style: TextStyle(
+                  fontSize: 18,
+                  color: Colors.black,
+                ),
+              ),
+            ),
+            const Divider(
+              thickness: 3,
+            ),
+
+            // 라이브러리 버튼
+            TextButton.icon(
+              onPressed: () {
+                getGalleryImage();
+              },
+              style: TextButton.styleFrom(
+                  minimumSize: const Size(double.infinity, 80),
+                  shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(0.0))),
+              icon: const Icon(
+                Icons.photo_album_outlined,
+                color: Colors.black,
+              ),
+              label: const Text(
+                '갤러리',
+                style: TextStyle(
+                  fontSize: 18,
+                  color: Colors.black,
+                ),
+              ),
+            ),
+          ],
+        );
+      },
     );
   }
 }


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
#44

## ✨ 코드 변경 내용
<!-- 코드 변경에 대한 설명을 적어주세요 -->
### 카메라와 갤러리 연동
- imagepicker 패키지 사용
- Info.plist파일에서 카메라, 사진, 마이크 권한 코드를 추가해야 틩김 현상 오류 해결
### 알리미 시작하기 버튼 기능 구현
- 프로필을 설정해야만 다음 페이지로 이동 가능하게 구현
- 설정을 안하고 이동할 시 "프로필을 설정하세요"라고 출력

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->
### 프로필 설정 페이지 UI
![Simulator Screenshot - iPhone 14 Pro Max(배달반도) - 2024-06-20 at 21 29 58](https://github.com/Jeong-Reminder/reminder-frontend/assets/127868094/46d374f7-e57f-4b64-bffc-e4608947f650)
### 프로필 설정하지 않았을 때와 설정했을 때 다음 페이지 이동
https://github.com/Jeong-Reminder/reminder-frontend/assets/127868094/05c99a7e-fcd9-484d-a7da-fdca41eb3a3d

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
