### PR TITLE
[Feat(admin)/#77] 관리자 회원가입 API 연동

### DIFF
--- a/frontend/lib/admin/providers/admin_provider.dart
+++ b/frontend/lib/admin/providers/admin_provider.dart
@@ -12,7 +12,7 @@ class AdminProvider with ChangeNotifier {
 
   // 학생들 정보를 담는 메소드를 호출(그래야만 학생들 정보를 admins에 담고 반환할 수 있음)
   // admins 반환
-  // 순서 : userInfo_screen에서 getMembers -> updateMember -> getMembers로 가서 admins 리턴
+  // 순서 : userInfo_screen에서 getMembers -> updateMember or createUser -> getMembers로 가서 admins 리턴
   Future<List<Admin>> getMembers(File file) async {
     if (await file.exists()) {
       await updateMembers(file);
@@ -24,11 +24,12 @@ class AdminProvider with ChangeNotifier {
     return admins;
   }
 
-  Future<void> addUser(Admin admin) async {
+  // 회원 추가
+  Future<void> createUser(Admin admin) async {
     try {
-      await userService.createUser(admin);
-      admins.add(admin);
-      notifyListeners();
+      await userService.createUser(admin); // 회원 추가 API를 호출
+      admins.add(admin); // 회원 정보 리스트(admins)에 추가
+      notifyListeners(); // 상태 변경 알림
     } catch (e) {
       print(e);
     }

--- a/frontend/lib/admin/screens/addMember_screen.dart
+++ b/frontend/lib/admin/screens/addMember_screen.dart
@@ -1,9 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:frontend/admin/models/admin_model.dart';
-import 'package:frontend/admin/providers/admin_provider.dart';
 import 'package:frontend/admin/services/userInfo_service.dart';
 import 'package:toggle_switch/toggle_switch.dart';
-import 'package:provider/provider.dart';
 
 class AddMemberPage extends StatefulWidget {
   const AddMemberPage({super.key});


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
#77

## ✨ 코드 변경 내용
<!-- 코드 변경에 대한 설명을 적어주세요 -->
### 관리자 회원 추가 페이지 구현
- toggle_switch 패키지 사용
###관리자 회원가입 API 코드 구현
- Provider 패키지를 활용하여 Provider를 생성해 데이터 변화 상태 알림
-  회원 추가 model를 생성해 회원 정보 생성
### 회원 추가한 정보를 admins에 추가하는 메소드 이름 변경

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->
https://github.com/Jeong-Reminder/reminder-frontend/assets/127868094/499becac-29f2-4b4a-920a-993545a680df

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
