### PR TITLE
[Feat/#86] 로그아웃 API 연동

### DIFF
--- a/frontend/ios/Podfile.lock
+++ b/frontend/ios/Podfile.lock
@@ -39,11 +39,9 @@ PODS:
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
-
   - SDWebImage (5.19.4):
     - SDWebImage/Core (= 5.19.4)
   - SDWebImage/Core (5.19.4)
-
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
@@ -81,11 +79,9 @@ SPEC CHECKSUMS:
   file_picker: 09aa5ec1ab24135ccd7a1621c46c84134bfd6655
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   image_picker_ios: 99dfe1854b4fa34d0364e74a78448a0151025425
-
   path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
   SDWebImage: 066c47b573f408f18caa467d71deace7c0f8280d
   shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
-
   SwiftyGif: 706c60cf65fa2bc5ee0313beece843c8eb8194d4
 
 PODFILE CHECKSUM: c4c93c5f6502fe2754f48404d3594bf779584011

--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:frontend/admin/screens/userInfo_screen.dart';
 import 'package:frontend/screens/login_screen.dart';
 import 'package:frontend/screens/myOwnerPage_screen.dart';
 import 'package:frontend/screens/myUserPage_screen.dart';
+import 'package:frontend/screens/settingProFile1_screen.dart';
 import 'package:provider/provider.dart';
 
 void main() {
@@ -30,6 +31,7 @@ class MyApp extends StatelessWidget {
         '/': (context) => const LoginPage(),
         '/add_member': (context) => const AddMemberPage(),
         '/user-info': (context) => const UserInfoPage(),
+        '/setting-profile': (context) => const SettingProfile1Page(),
       },
     );
   }

--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -3,6 +3,8 @@ import 'package:frontend/admin/providers/admin_provider.dart';
 import 'package:frontend/admin/screens/addMember_screen.dart';
 import 'package:frontend/admin/screens/userInfo_screen.dart';
 import 'package:frontend/screens/login_screen.dart';
+import 'package:frontend/screens/myOwnerPage_screen.dart';
+import 'package:frontend/screens/myUserPage_screen.dart';
 import 'package:provider/provider.dart';
 
 void main() {
@@ -32,3 +34,69 @@ class MyApp extends StatelessWidget {
     );
   }
 }
+
+
+
+
+// import 'package:flutter/material.dart';
+// import 'package:frontend/admin/providers/admin_provider.dart';
+// import 'package:frontend/admin/screens/addMember_screen.dart';
+// import 'package:frontend/admin/screens/userInfo_screen.dart';
+// import 'package:frontend/screens/login_screen.dart';
+// import 'package:provider/provider.dart';
+// import 'package:frontend/services/login_services.dart';
+
+// void main() {
+//   WidgetsFlutterBinding.ensureInitialized();
+//   runApp(
+//     MultiProvider(
+//       providers: [
+//         ChangeNotifierProvider(create: (_) => AdminProvider()),
+//       ],
+//       child: const MyApp(),
+//     ),
+//   );
+// }
+
+// class MyApp extends StatefulWidget {
+//   const MyApp({super.key});
+
+//   @override
+//   _MyAppState createState() => _MyAppState();
+// }
+
+// class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
+//   final LoginAPI _loginAPI = LoginAPI(); // LoginAPI 인스턴스 생성
+
+//   @override
+//   void initState() {
+//     super.initState();
+//     WidgetsBinding.instance.addObserver(this); // 앱 라이프사이클 이벤트 관찰 시작
+//   }
+
+//   @override
+//   void dispose() {
+//     WidgetsBinding.instance.removeObserver(this); // 앱 라이프사이클 이벤트 관찰 중지
+//     super.dispose();
+//   }
+
+//   @override
+//   void didChangeAppLifecycleState(AppLifecycleState state) {
+//     if (state == AppLifecycleState.detached ||
+//         state == AppLifecycleState.inactive) {
+//       _loginAPI.logout(); // 앱이 종료되거나 비활성화될 때 로그아웃 호출
+//     }
+//   }
+
+//   @override
+//   Widget build(BuildContext context) {
+//     return MaterialApp(
+//       initialRoute: '/',
+//       routes: {
+//         '/': (context) => const LoginPage(),
+//         '/add_member': (context) => const AddMemberPage(),
+//         '/user-info': (context) => const UserInfoPage(),
+//       },
+//     );
+//   }
+// }

--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -3,10 +3,9 @@ import 'package:frontend/admin/providers/admin_provider.dart';
 import 'package:frontend/admin/screens/addMember_screen.dart';
 import 'package:frontend/admin/screens/userInfo_screen.dart';
 import 'package:frontend/screens/login_screen.dart';
-import 'package:frontend/screens/myOwnerPage_screen.dart';
-import 'package:frontend/screens/myUserPage_screen.dart';
 import 'package:frontend/screens/settingProFile1_screen.dart';
 import 'package:provider/provider.dart';
+import 'package:frontend/services/login_services.dart';
 
 void main() {
   WidgetsFlutterBinding.ensureInitialized();
@@ -20,8 +19,35 @@ void main() {
   );
 }
 
-class MyApp extends StatelessWidget {
+class MyApp extends StatefulWidget {
   const MyApp({super.key});
+
+  @override
+  _MyAppState createState() => _MyAppState();
+}
+
+class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
+  final LoginAPI _loginAPI = LoginAPI(); // LoginAPI 인스턴스 생성
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this); // 앱 라이프사이클 이벤트 관찰 시작
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this); // 앱 라이프사이클 이벤트 관찰 중지
+    super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.detached ||
+        state == AppLifecycleState.inactive) {
+      _loginAPI.logoutOnExit(); // 앱이 종료되거나 비활성화될 때 로그아웃 호출
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -36,69 +62,3 @@ class MyApp extends StatelessWidget {
     );
   }
 }
-
-
-
-
-// import 'package:flutter/material.dart';
-// import 'package:frontend/admin/providers/admin_provider.dart';
-// import 'package:frontend/admin/screens/addMember_screen.dart';
-// import 'package:frontend/admin/screens/userInfo_screen.dart';
-// import 'package:frontend/screens/login_screen.dart';
-// import 'package:provider/provider.dart';
-// import 'package:frontend/services/login_services.dart';
-
-// void main() {
-//   WidgetsFlutterBinding.ensureInitialized();
-//   runApp(
-//     MultiProvider(
-//       providers: [
-//         ChangeNotifierProvider(create: (_) => AdminProvider()),
-//       ],
-//       child: const MyApp(),
-//     ),
-//   );
-// }
-
-// class MyApp extends StatefulWidget {
-//   const MyApp({super.key});
-
-//   @override
-//   _MyAppState createState() => _MyAppState();
-// }
-
-// class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
-//   final LoginAPI _loginAPI = LoginAPI(); // LoginAPI 인스턴스 생성
-
-//   @override
-//   void initState() {
-//     super.initState();
-//     WidgetsBinding.instance.addObserver(this); // 앱 라이프사이클 이벤트 관찰 시작
-//   }
-
-//   @override
-//   void dispose() {
-//     WidgetsBinding.instance.removeObserver(this); // 앱 라이프사이클 이벤트 관찰 중지
-//     super.dispose();
-//   }
-
-//   @override
-//   void didChangeAppLifecycleState(AppLifecycleState state) {
-//     if (state == AppLifecycleState.detached ||
-//         state == AppLifecycleState.inactive) {
-//       _loginAPI.logout(); // 앱이 종료되거나 비활성화될 때 로그아웃 호출
-//     }
-//   }
-
-//   @override
-//   Widget build(BuildContext context) {
-//     return MaterialApp(
-//       initialRoute: '/',
-//       routes: {
-//         '/': (context) => const LoginPage(),
-//         '/add_member': (context) => const AddMemberPage(),
-//         '/user-info': (context) => const UserInfoPage(),
-//       },
-//     );
-//   }
-// }

--- a/frontend/lib/screens/login_screen.dart
+++ b/frontend/lib/screens/login_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:frontend/screens/settingProFile1_screen.dart';
+import 'package:frontend/admin/screens/userInfo_screen.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:frontend/services/login_services.dart';
 
@@ -165,11 +166,8 @@ class _LoginPageState extends State<LoginPage> {
                         if (value == null || value.isEmpty) {
                           return '비밀번호를 입력하세요';
                         }
-                        if (value.length > 15) {
-                          return '15자 이하로 작성해주세요';
-                        }
-                        if (!RegExp(r'^(?=.*[a-zA-Z])').hasMatch(value)) {
-                          return '영문자가 포함되어야 합니다';
+                        if (value.length < 4 && value.length > 15) {
+                          return '4자 이상 15자 이하로 작성해주세요';
                         }
                         return null;
                       },
@@ -229,20 +227,22 @@ class _LoginPageState extends State<LoginPage> {
                     String password = pwController.text;
                     loginAPI
                         .handleLogin(studentId, password)
-                        .then((isLoggedIn) async {
-                      if (isLoggedIn) {
+                        .then((result) async {
+                      if (result['success']) {
                         final prefs = await SharedPreferences.getInstance();
                         if (isAutoLogin) {
                           // 자동 로그인 체크 시에만 학번과 비밀번호 저장
                           await prefs.setString('studentId', studentId);
                           await prefs.setString('password', password);
                         }
-                        Navigator.pushReplacement(
-                          context,
-                          MaterialPageRoute(
-                            builder: (context) => const SettingProfile1Page(),
-                          ),
-                        );
+                        // userRole 값에 따라 다른 페이지로 이동
+                        if (result['role'] == 'ROLE_ADMIN') {
+                          Navigator.pushNamed(context, '/user-info');
+                        } else if (result['role'] == 'ROLE_USER') {
+                          Navigator.pushNamed(context, '/setting-profile');
+                        }
+                      } else {
+                        // 로그인 실패 처리
                       }
                     });
                   }

--- a/frontend/lib/screens/login_screen.dart
+++ b/frontend/lib/screens/login_screen.dart
@@ -228,9 +228,15 @@ class _LoginPageState extends State<LoginPage> {
                     String studentId = idController.text;
                     String password = pwController.text;
                     loginAPI
-                        .handleLogin(studentId, password, isAutoLogin)
-                        .then((isLoggedIn) {
+                        .handleLogin(studentId, password)
+                        .then((isLoggedIn) async {
                       if (isLoggedIn) {
+                        final prefs = await SharedPreferences.getInstance();
+                        if (isAutoLogin) {
+                          // 자동 로그인 체크 시에만 학번과 비밀번호 저장
+                          await prefs.setString('studentId', studentId);
+                          await prefs.setString('password', password);
+                        }
                         Navigator.pushReplacement(
                           context,
                           MaterialPageRoute(

--- a/frontend/lib/screens/login_screen.dart
+++ b/frontend/lib/screens/login_screen.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:frontend/screens/settingProFile1_screen.dart';
-import 'package:frontend/admin/screens/userInfo_screen.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:frontend/services/login_services.dart';
 

--- a/frontend/lib/services/login_services.dart
+++ b/frontend/lib/services/login_services.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'package:http/http.dart' as http;
 import 'package:cookie_jar/cookie_jar.dart';
 import 'package:path_provider/path_provider.dart';
@@ -129,7 +130,8 @@ class LoginAPI {
   }
 
   // 로그인 API
-  Future<bool> handleLogin(String studentId, String password) async {
+  Future<Map<String, dynamic>> handleLogin(
+      String studentId, String password) async {
     try {
       final url = Uri.parse(loginAddress);
 
@@ -146,6 +148,9 @@ class LoginAPI {
       print('로그인 응답 본문: ${response.body}');
 
       if (response.statusCode == 200) {
+        final responseData = jsonDecode(response.body);
+        final userRole = responseData['userRole'];
+
         final accessToken = response.headers['access']; // 액세스 토큰 추출
         final setCookieHeader = response.headers['set-cookie'];
         final refreshToken = setCookieHeader != null
@@ -172,14 +177,22 @@ class LoginAPI {
           print('저장된 리프레시 토큰: $savedRefreshToken');
         }
         print('로그인 성공');
-        return true;
+
+        return {
+          'success': true,
+          'role': userRole,
+        };
       } else {
         print('로그인 실패: ${response.statusCode} ${response.body}');
-        return false;
+        return {
+          'success': false,
+        };
       }
     } catch (e) {
       print('로그인 요청 중 에러 발생: ${e.toString()}');
-      return false;
+      return {
+        'success': false,
+      };
     }
   }
 

--- a/frontend/lib/services/login_services.dart
+++ b/frontend/lib/services/login_services.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:http/http.dart' as http;
 import 'package:cookie_jar/cookie_jar.dart';
 import 'package:path_provider/path_provider.dart';
@@ -129,8 +128,7 @@ class LoginAPI {
   }
 
   // 로그인 API
-  Future<bool> handleLogin(
-      String studentId, String password, bool isAutoLogin) async {
+  Future<bool> handleLogin(String studentId, String password) async {
     try {
       final url = Uri.parse(loginAddress);
 
@@ -161,18 +159,6 @@ class LoginAPI {
           // 새 토큰 저장
           await prefs.setString('accessToken', accessToken); // 액세스 토큰 저장
           await prefs.setString('refreshToken', refreshToken); // 리프레시 토큰 저장
-
-          // 자동 로그인 상태 저장
-          await prefs.setBool('isAutoLogin', isAutoLogin);
-          if (isAutoLogin) {
-            // 자동 로그인 체크 시에만 학번과 비밀번호 저장
-            await prefs.setString('studentId', studentId);
-            await prefs.setString('password', password);
-          } else {
-            // 체크 해제 시 저장된 학번과 비밀번호 삭제
-            await prefs.remove('studentId');
-            await prefs.remove('password');
-          }
 
           final uri = Uri.parse(loginAddress);
           cookieJar.saveFromResponse(uri,

--- a/frontend/lib/widgets/account_widget.dart
+++ b/frontend/lib/widgets/account_widget.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:frontend/screens/login_screen.dart';
 
 class AccountWidget extends StatelessWidget {
   const AccountWidget({super.key});
@@ -119,6 +120,12 @@ class AccountWidget extends StatelessWidget {
                 TextButton(
                   onPressed: () {
                     // 로그인 화면으로 이동
+                    Navigator.pushReplacement(
+                      context,
+                      MaterialPageRoute(
+                        builder: (context) => const LoginPage(),
+                      ),
+                    );
                   },
                   style: TextButton.styleFrom(
                     fixedSize: const Size(100, 20),

--- a/frontend/lib/widgets/account_widget.dart
+++ b/frontend/lib/widgets/account_widget.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:frontend/screens/login_screen.dart';
+import 'package:frontend/services/login_services.dart';
 
 class AccountWidget extends StatelessWidget {
   const AccountWidget({super.key});
@@ -87,7 +88,6 @@ class AccountWidget extends StatelessWidget {
               Text("정말 로그아웃 하실 건가요?"),
             ],
           ),
-          //
           content: const Column(
             mainAxisSize: MainAxisSize.min,
             crossAxisAlignment: CrossAxisAlignment.center,
@@ -118,14 +118,15 @@ class AccountWidget extends StatelessWidget {
                   ),
                 ),
                 TextButton(
-                  onPressed: () {
-                    // 로그인 화면으로 이동
-                    Navigator.pushReplacement(
-                      context,
-                      MaterialPageRoute(
-                        builder: (context) => const LoginPage(),
-                      ),
-                    );
+                  onPressed: () async {
+                    final loginAPI = LoginAPI();
+                    bool success = await loginAPI.logout();
+                    if (success) {
+                      // 로그인 화면으로 이동
+                      Navigator.pushNamed(context, '/');
+                    } else {
+                      Navigator.pop(context);
+                    }
                   },
                   style: TextButton.styleFrom(
                     fixedSize: const Size(100, 20),

--- a/frontend/lib/widgets/account_widget.dart
+++ b/frontend/lib/widgets/account_widget.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:frontend/screens/login_screen.dart';
 import 'package:frontend/services/login_services.dart';
 
 class AccountWidget extends StatelessWidget {

--- a/frontend/pubspec.lock
+++ b/frontend/pubspec.lock
@@ -621,6 +621,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.0"
+  toggle_switch:
+    dependency: "direct main"
+    description:
+      name: toggle_switch
+      sha256: dca04512d7c23ed320d6c5ede1211a404f177d54d353bf785b07d15546a86ce5
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.0"
   typed_data:
     dependency: transitive
     description:

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -47,6 +47,7 @@ dependencies:
     jwt_decoder: ^2.0.1
     path: ^1.8.3
     provider: ^6.1.2
+    toggle_switch: ^2.3.0
 
 dev_dependencies:
     flutter_test:


### PR DESCRIPTION
## 📌 관련 이슈
#86 

## ✨ 코드 변경 내용
- AppLifecycleState 상태를 관찰하는 addObserver 매서드와 관찰을 중지하는 removeObserver 매서드를 활용하여 상태 인지되도록 구현
- 앱이 종료되거나 비활성화되는 경우의 AppLifecycleState 상태에 따라 logout API 호출되도록 구현
- 앱 종료 시  logout API  호출되도록 하는 logoutOnExit 함수 선언하여 관리되도록 구현

## 📸 스크린샷(선택)


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
- AppLifecycleState 상태를 관찰하는 addObserver 매서드와 관찰을 중지하는 removeObserver 매서드를 활용하여 상태 인지되도록 구현
- 앱이 종료되거나 비활성화되는 경우의 AppLifecycleState 상태에 따라 logout API 호출되도록 구현
