### PR TITLE
[Feat/#89] 프로필 생성 API 연동

### DIFF
--- a/frontend/lib/models/profile_model.dart
+++ b/frontend/lib/models/profile_model.dart
@@ -1,0 +1,36 @@
+class Profile {
+  String? hopeJob;
+  String? githubLink;
+  String? developmentField;
+  String? developmentTool;
+
+  Profile({
+    required this.hopeJob,
+    required this.githubLink,
+    required this.developmentField,
+    required this.developmentTool,
+  });
+
+  factory Profile.fromJson(Map<String, dynamic> json) {
+    return Profile(
+      hopeJob: json['hopeJob'],
+      githubLink: json['githubLink'],
+      developmentField: json['developmentField'],
+      developmentTool: json['developmentTool'],
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'hopeJob': hopeJob,
+      'githubLink': githubLink,
+      'developmentField': developmentField,
+      'developmentTool': developmentTool,
+    };
+  }
+
+  @override
+  String toString() {
+    return 'hopeJob: $hopeJob, githubLink: $githubLink, developmentField: $developmentField, developmentTool: $developmentTool';
+  }
+}

--- a/frontend/lib/providers/profile_provider.dart
+++ b/frontend/lib/providers/profile_provider.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+import 'package:frontend/models/profile_model.dart';
+import 'package:frontend/services/profile_service.dart';
+
+class ProfileProvider with ChangeNotifier {
+  ProfileService profileService = ProfileService();
+
+  Profile? profile;
+
+  // 프로필 생성
+  Future<void> createProfile(Profile profile) async {
+    try {
+      await profileService.createProfile(profile);
+
+      this.profile = profile;
+      notifyListeners();
+      print("생성된 프로필: ${this.profile}");
+    } catch (e) {
+      print('프로필 생성 실패 : ${e.toString()}');
+    }
+  }
+}

--- a/frontend/lib/screens/login_screen.dart
+++ b/frontend/lib/screens/login_screen.dart
@@ -1,7 +1,13 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
+import 'package:frontend/screens/home_screen.dart';
 import 'package:frontend/screens/settingProFile1_screen.dart';
+import 'package:http/http.dart' as http;
+import 'package:cookie_jar/cookie_jar.dart';
+import 'package:path_provider/path_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:frontend/services/login_services.dart';
+import 'package:jwt_decoder/jwt_decoder.dart';
 
 class LoginPage extends StatefulWidget {
   const LoginPage({super.key});
@@ -13,25 +19,49 @@ class LoginPage extends StatefulWidget {
 class _LoginPageState extends State<LoginPage> {
   TextEditingController idController = TextEditingController();
   TextEditingController pwController = TextEditingController();
-  final LoginAPI loginAPI = LoginAPI(); // API 객체 생성
 
   bool isAutoLogin = false;
   bool pwInvisible = true; // 비밀번호 숨김 기본값 true
+  late PersistCookieJar cookieJar; // 쿠키를 관리할 객체
 
   final formKey = GlobalKey<FormState>(); // 폼 유효성을 검사하는데 사용
+
+  // 로그인 및 토큰 재발급을 위한 서버 주소 상수
+  static const loginAddress = 'https://reminder.sungkyul.ac.kr/login';
+  static const tokenRefreshAddress =
+      'https://reminder.sungkyul.ac.kr/api/v1/reissue';
 
   @override
   void initState() {
     super.initState();
+    _initCookieJar(); // 초기화 함수 호출
     _autoLogin(); // 자동 로그인 시도
+  }
+
+  // refreshToken 추출 메서드
+  String? extractRefreshToken(String setCookieHeader) {
+    final regex = RegExp(r'refresh=([^;]+)');
+    final match = regex.firstMatch(setCookieHeader);
+    return match?.group(1);
+  }
+
+  // 쿠키 관리를 위한 초기화 함수
+  Future<void> _initCookieJar() async {
+    final appDocDir =
+        await getApplicationDocumentsDirectory(); // 앱의 문서 디렉토리 경로 가져오기
+    final appDocPath = appDocDir.path; // 디렉토리 경로 저장
+    print('쿠키 저장 경로: $appDocPath/.cookies/'); // 디버그 출력
+    cookieJar = PersistCookieJar(
+      storage: FileStorage('$appDocPath/.cookies/'), // 파일 저장소로 쿠키 저장
+    );
   }
 
   // 저장된 학번과 비밀번호 불러오기
   Future<void> _loadCredentials() async {
-    final credentials = await loginAPI.loadCredentials();
-    final studentId = credentials['studentId'];
-    final password = credentials['password'];
-    final autoLogin = credentials['isAutoLogin'];
+    final prefs = await SharedPreferences.getInstance();
+    final studentId = prefs.getString('studentId');
+    final password = prefs.getString('password');
+    final autoLogin = prefs.getBool('isAutoLogin') ?? false;
 
     if (studentId != null && password != null && autoLogin) {
       setState(() {
@@ -42,18 +72,187 @@ class _LoginPageState extends State<LoginPage> {
     }
   }
 
-  // 자동 로그인 시 페이지 이동 적용
+  // 자동 로그인 시도 함수
   Future<void> _autoLogin() async {
     await _loadCredentials();
-    final isAutoLoggedIn = await loginAPI.autoLogin();
+    final prefs = await SharedPreferences.getInstance();
+    final accessToken = prefs.getString('accessToken');
+    final studentId = prefs.getString('studentId');
+    final password = prefs.getString('password');
 
-    if (isAutoLoggedIn) {
-      Navigator.pushReplacement(
-        context,
-        MaterialPageRoute(
-          builder: (context) => const SettingProfile1Page(),
-        ),
+    if (accessToken != null && studentId != null && password != null) {
+      final isExpired = JwtDecoder.isExpired(accessToken);
+      if (isExpired) {
+        await againToken(); // 토큰 재발급 시도
+      } else {
+        print('유효한 토큰이 존재합니다.');
+        Navigator.pushReplacement(
+          context,
+          MaterialPageRoute(
+            builder: (context) => const SettingProfile1Page(),
+          ),
+        );
+      }
+    }
+  }
+
+  // 이전 토큰 삭제 함수
+  Future<void> clearTokens() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove('accessToken');
+    await prefs.remove('refreshToken');
+    await cookieJar.deleteAll(); // 쿠키 삭제
+  }
+
+  // 토큰 재발급 API
+  Future<void> againToken() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final refreshToken = prefs.getString('refreshToken') ?? '';
+
+      if (refreshToken.isEmpty) {
+        print('invalid refresh token');
+        return;
+      }
+
+      final url = Uri.parse(tokenRefreshAddress);
+      final cookieHeader = 'refresh=$refreshToken';
+
+      final response = await http.post(url, headers: {
+        'Cookie': cookieHeader,
+      });
+
+      print('토큰 재발급 응답 상태 코드: ${response.statusCode}');
+
+      if (response.statusCode == 200) {
+        final newAccessToken = response.headers['access'];
+        final setCookieHeader = response.headers['set-cookie'];
+        print('새로운 엑세스 토큰 $newAccessToken');
+
+        final newRefreshToken = setCookieHeader != null
+            ? extractRefreshToken(setCookieHeader)
+            : null;
+        print('새로운 리프래시 토큰 $newRefreshToken');
+
+        if (newAccessToken != null && newRefreshToken != null) {
+          await clearTokens();
+
+          await prefs.setString('accessToken', newAccessToken);
+          await prefs.setString('refreshToken', newRefreshToken);
+
+          final uri = Uri.parse(tokenRefreshAddress);
+          cookieJar.saveFromResponse(uri, [Cookie('refresh', newRefreshToken)]);
+        } else {
+          print('응답 데이터에 토큰이 없습니다');
+        }
+
+        print('토큰 재발급 성공!');
+        // 토큰 재발급 성공 시
+        Navigator.pushReplacement(
+          context,
+          MaterialPageRoute(
+            builder: (context) => const SettingProfile1Page(),
+          ),
+        );
+      } else {
+        print('토큰 재발급 실패: ${response.statusCode} ${response.body}');
+      }
+    } catch (e) {
+      print('토큰 재발급 요청 중 에러 발생: ${e.toString()}');
+    }
+  }
+
+  // 로그인 API
+  Future<void> handleLogin(String studentId, String password) async {
+    try {
+      final url = Uri.parse(loginAddress);
+
+      // HTTP POST 요청 전송
+      final response = await http.post(
+        url,
+        body: {
+          'studentId': studentId,
+          'password': password,
+        },
       );
+
+      print('로그인 응답 상태 코드: ${response.statusCode}');
+      print('로그인 응답 본문: ${response.body}');
+
+      if (response.statusCode == 200) {
+        final responseData = jsonDecode(response.body);
+        final userRole = responseData['userRole'];
+        final techStack = responseData['techStack'];
+
+        final accessToken = response.headers['access']; // 액세스 토큰 추출
+        final setCookieHeader = response.headers['set-cookie'];
+        final refreshToken = setCookieHeader != null
+            ? extractRefreshToken(setCookieHeader)
+            : null;
+
+        final prefs = await SharedPreferences.getInstance();
+        if (accessToken != null && refreshToken != null) {
+          // 이전 토큰 삭제
+          await clearTokens();
+
+          // 새 토큰 저장
+          await prefs.setString('accessToken', accessToken); // 액세스 토큰 저장
+          await prefs.setString('refreshToken', refreshToken); // 리프레시 토큰 저장
+
+          // 자동 로그인 상태 저장
+          await prefs.setBool('isAutoLogin', isAutoLogin);
+          if (isAutoLogin) {
+            // 자동 로그인 체크 시에만 학번과 비밀번호 저장
+            await prefs.setString('studentId', studentId);
+            await prefs.setString('password', password);
+          } else {
+            // 체크 해제 시 저장된 학번과 비밀번호 삭제
+            await prefs.remove('studentId');
+            await prefs.remove('password');
+          }
+
+          final uri = Uri.parse(loginAddress);
+          cookieJar.saveFromResponse(
+              uri, [Cookie('refreshToken', refreshToken)]); // 쿠키 저장
+
+          // 저장된 토큰 로그로 확인
+          final savedAccessToken = prefs.getString('accessToken');
+          final savedRefreshToken = prefs.getString('refreshToken');
+          print('저장된 액세스 토큰: $savedAccessToken');
+          print('저장된 리프레시 토큰: $savedRefreshToken');
+        }
+        print('로그인 성공');
+
+        if (userRole == 'ROLE_ADMIN') {
+          Navigator.pushNamed(
+            context,
+            '/user-info',
+          );
+        } else if (userRole == 'ROLE_USER') {
+          if (context.mounted) {
+            if (techStack != null && techStack.isNotEmpty) {
+              // isNotEmpty를 호출하기 전에 해당 변수가 null인지 확인해야 함
+              Navigator.pushReplacement(
+                context,
+                MaterialPageRoute(
+                  builder: (context) => const HomePage(),
+                ),
+              );
+            } else {
+              Navigator.pushReplacement(
+                context,
+                MaterialPageRoute(
+                  builder: (context) => const SettingProfile1Page(),
+                ),
+              );
+            }
+          }
+        }
+      } else {
+        print('로그인 실패: ${response.statusCode} ${response.body}');
+      }
+    } catch (e) {
+      print('로그인 요청 중 에러 발생: ${e.toString()}');
     }
   }
 
@@ -168,9 +367,9 @@ class _LoginPageState extends State<LoginPage> {
                         if (value.length > 15) {
                           return '15자 이하로 작성해주세요';
                         }
-                        if (!RegExp(r'^(?=.*[a-zA-Z])').hasMatch(value)) {
-                          return '영문자가 포함되어야 합니다';
-                        }
+                        // if (!RegExp(r'^(?=.*[a-zA-Z])').hasMatch(value)) {
+                        //   return '영문자가 포함되어야 합니다';
+                        // }
                         return null;
                       },
                       autovalidateMode: AutovalidateMode.onUserInteraction,
@@ -227,18 +426,7 @@ class _LoginPageState extends State<LoginPage> {
                   if (formKey.currentState!.validate()) {
                     String studentId = idController.text;
                     String password = pwController.text;
-                    loginAPI
-                        .handleLogin(studentId, password, isAutoLogin)
-                        .then((isLoggedIn) {
-                      if (isLoggedIn) {
-                        Navigator.pushReplacement(
-                          context,
-                          MaterialPageRoute(
-                            builder: (context) => const SettingProfile1Page(),
-                          ),
-                        );
-                      }
-                    });
+                    handleLogin(studentId, password);
                   }
                 },
                 style: ElevatedButton.styleFrom(
@@ -259,6 +447,25 @@ class _LoginPageState extends State<LoginPage> {
               ),
             ],
           ),
+        ),
+      ),
+    );
+  }
+
+  // 아이디 / 비밀번호 찾기 텍스트 버튼
+  Widget idAndPwTextBtn(String title) {
+    return TextButton(
+      onPressed: () {},
+      style: TextButton.styleFrom(
+        minimumSize: Size.zero,
+        padding: EdgeInsets.zero,
+        tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+      ),
+      child: Text(
+        title,
+        style: const TextStyle(
+          fontWeight: FontWeight.bold,
+          color: Color(0xFF808080),
         ),
       ),
     );

--- a/frontend/lib/screens/settingProFile1_screen.dart
+++ b/frontend/lib/screens/settingProFile1_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:badges/badges.dart' as badges;
+import 'package:frontend/providers/profile_provider.dart';
 import 'package:frontend/screens/settingProfile_screen.dart';
 import 'package:percent_indicator/linear_percent_indicator.dart';
 
@@ -14,6 +15,7 @@ class _SettingProfile1PageState extends State<SettingProfile1Page> {
   double percent = 0; // 프로그레스 바 진행률
   TextEditingController linkController = TextEditingController(); // 깃허브 링크 입력
   bool writtenLink = false;
+  String githubUrl = '';
 
   @override
   void initState() {
@@ -179,7 +181,7 @@ class _SettingProfile1PageState extends State<SettingProfile1Page> {
                       ),
 
                       // github.com 고정
-                      prefixText: 'github.com/',
+                      prefixText: 'https://github.com/',
                       prefixStyle: TextStyle(
                         fontSize: 14,
                         color: Colors.black,
@@ -207,10 +209,10 @@ class _SettingProfile1PageState extends State<SettingProfile1Page> {
                 // writtenLink이 false일 때 깃허브 링크 화면에서 진행
                 if (!writtenLink) {
                   if (linkController.text.isNotEmpty) {
-                    final githubUrl =
-                        'github.com/${linkController.text}'; // 깃허브 링크 최종 주소
-                    print('깃허브 링크 : $githubUrl');
-                    // 이 자리에 api 작성
+                    setState(() {
+                      githubUrl =
+                          'https://github.com/${linkController.text}'; // 깃허브 링크 최종 주소
+                    });
                   } else {
                     print('깃허브 링크 없음');
                   }
@@ -225,7 +227,10 @@ class _SettingProfile1PageState extends State<SettingProfile1Page> {
                   Navigator.push(
                     context,
                     MaterialPageRoute(
-                      builder: (context) => const SettingProfilePage(),
+                      builder: (context) => SettingProfilePage(
+                        githubUrl,
+                        chosenpositionList[0]['title'],
+                      ),
                     ),
                   );
                 }

--- a/frontend/lib/screens/settingProfile_screen.dart
+++ b/frontend/lib/screens/settingProfile_screen.dart
@@ -1,16 +1,23 @@
 import 'package:flutter/material.dart';
 import 'package:badges/badges.dart' as badges;
+import 'package:frontend/models/profile_model.dart';
 import 'package:frontend/screens/home_screen.dart';
+import 'package:frontend/services/profile_service.dart';
 import 'package:percent_indicator/percent_indicator.dart';
 
 class SettingProfilePage extends StatefulWidget {
-  const SettingProfilePage({super.key});
+  final String githubLink;
+  final String hopeJob;
+  const SettingProfilePage(this.githubLink, this.hopeJob, {super.key});
 
   @override
   State<SettingProfilePage> createState() => _SettingProfilePageState();
 }
 
 class _SettingProfilePageState extends State<SettingProfilePage> {
+  String developmentField = '';
+  String developmentTool = '';
+
   List<Map<String, dynamic>> fieldList = [
     {
       'logoUrl': 'assets/skilImages/typescript.png',
@@ -62,13 +69,6 @@ class _SettingProfilePageState extends State<SettingProfilePage> {
       'isSelected': false,
     },
     {
-      'logoUrl': 'assets/skilImages/vscode.png',
-      'title': 'VISUAL STUDIO CODE',
-      'titleColor': Colors.white,
-      'badgeColor': const Color(0xFF0078D7),
-      'isSelected': false,
-    },
-    {
       'logoUrl': 'assets/skilImages/docker.png',
       'title': 'DOCKER',
       'titleColor': Colors.white,
@@ -101,6 +101,13 @@ class _SettingProfilePageState extends State<SettingProfilePage> {
       'title': 'FIGMA',
       'titleColor': Colors.white,
       'badgeColor': const Color(0xFFF24D1D),
+      'isSelected': false,
+    },
+    {
+      'logoUrl': 'assets/skilImages/vscode.png',
+      'title': 'VISUAL STUDIO CODE',
+      'titleColor': Colors.white,
+      'badgeColor': const Color(0xFF0078D7),
       'isSelected': false,
     },
   ];
@@ -373,7 +380,7 @@ class _SettingProfilePageState extends State<SettingProfilePage> {
                 ),
                 const SizedBox(height: 15),
                 ElevatedButton(
-                  onPressed: () {
+                  onPressed: () async {
                     if (!completedField) {
                       setState(() {
                         completedField = true;
@@ -381,12 +388,43 @@ class _SettingProfilePageState extends State<SettingProfilePage> {
                         percent = 0.75;
                       });
                     } else {
-                      Navigator.push(
-                        context,
-                        MaterialPageRoute(
-                          builder: (context) => const HomePage(),
-                        ),
+                      setState(() {
+                        // selectedFields에서 title들을 가져와 하나의 문자열로 생성
+                        developmentField = selectedFields
+                            .map((f) => f['title'])
+                            .toList()
+                            .join(',');
+
+                        // selectedTools에서 title들을 가져와 하나의 문자열로 생성
+                        developmentTool = selectedTools
+                            .map((t) => t['title'])
+                            .toList()
+                            .join(','); // 요소 사이에 콤마(,) 추가
+                      });
+
+                      // body에 집어넣을 프로필 model
+                      final profile = Profile(
+                        hopeJob: widget.hopeJob,
+                        githubLink: widget.githubLink,
+                        developmentField: developmentField,
+                        developmentTool: developmentTool,
                       );
+
+                      print('profile: $profile');
+
+                      try {
+                        await ProfileService().createProfile(profile);
+                        if (context.mounted) {
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder: (context) => const HomePage(),
+                            ),
+                          );
+                        }
+                      } catch (e) {
+                        print(e.toString());
+                      }
                     }
                   },
                   style: ElevatedButton.styleFrom(

--- a/frontend/lib/screens/settingProfile_screen.dart
+++ b/frontend/lib/screens/settingProfile_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:badges/badges.dart' as badges;
 import 'package:frontend/models/profile_model.dart';
+import 'package:frontend/providers/profile_provider.dart';
 import 'package:frontend/screens/home_screen.dart';
 import 'package:frontend/services/profile_service.dart';
 import 'package:percent_indicator/percent_indicator.dart';
@@ -413,7 +414,7 @@ class _SettingProfilePageState extends State<SettingProfilePage> {
                       print('profile: $profile');
 
                       try {
-                        await ProfileService().createProfile(profile);
+                        await ProfileProvider().createProfile(profile);
                         if (context.mounted) {
                           Navigator.push(
                             context,

--- a/frontend/lib/services/profile_service.dart
+++ b/frontend/lib/services/profile_service.dart
@@ -1,0 +1,38 @@
+import 'dart:convert';
+
+import 'package:frontend/models/profile_model.dart';
+import 'package:http/http.dart' as http;
+import 'package:shared_preferences/shared_preferences.dart';
+
+class ProfileService {
+  Future<String?> getToken() async {
+    SharedPreferences prefs = await SharedPreferences.getInstance();
+    return prefs.getString('accessToken'); // accessToken 키로 저장된 문자열 값을 가져옴
+  }
+
+  Future<void> createProfile(Profile profile) async {
+    const String baseUrl =
+        'https://reminder.sungkyul.ac.kr/api/v1/member-profile';
+
+    final accessToken = await getToken();
+    if (accessToken == null) {
+      throw Exception('엑세스 토큰을 찾을 수 없음');
+    }
+
+    final url = Uri.parse(baseUrl);
+    final response = await http.post(
+      url,
+      headers: <String, String>{
+        'Content-Type': 'application/json',
+        'access': accessToken,
+      },
+      body: jsonEncode(profile.toJson()),
+    );
+
+    if (response.statusCode == 200) {
+      print('생성 성공');
+    } else {
+      print('생성 실패: ${response.statusCode} - ${response.body}');
+    }
+  }
+}


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
#89

## ✨ 코드 변경 내용
<!-- 코드 변경에 대한 설명을 적어주세요 -->
### 프로필 생성 api 연동
- profile 모델 생성
- githubUrl과 hopeJob은 settingprofile 페이지로 전달
- 선택한 field와 tool 리스트를 map 메소드와 join 메소드를 활용하여 하나의 문자열로 변환
### 프로필 provider 구현
- 상태 관리할 profile을 위해 생성
- techStack.isNotEmpty를 하기 전에 null인지 아닌지 확인해야 함
- 프로필 생성 시 ProfileProvider 호출

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->
### 프로필 생성 전
<img width="605" alt="스크린샷 2024-07-16 오후 10 23 45" src="https://github.com/user-attachments/assets/ed6bfce1-c373-469a-822a-8f5fa29a0b0b">

### 프로필 생성 후
<img width="660" alt="스크린샷 2024-07-16 오후 10 24 02" src="https://github.com/user-attachments/assets/49e3ddf5-00b0-4d82-93ee-2f61a109905d">

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
