### PR TITLE
[Feat/#91] 프로젝트 경험 추가 API 연동

### DIFF
--- a/frontend/ios/Podfile.lock
+++ b/frontend/ios/Podfile.lock
@@ -79,9 +79,9 @@ SPEC CHECKSUMS:
   file_picker: 09aa5ec1ab24135ccd7a1621c46c84134bfd6655
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   image_picker_ios: 99dfe1854b4fa34d0364e74a78448a0151025425
-  path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
+  path_provider_foundation: 3784922295ac71e43754bd15e0653ccfd36a147c
   SDWebImage: 066c47b573f408f18caa467d71deace7c0f8280d
-  shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
+  shared_preferences_foundation: b4c3b4cddf1c21f02770737f147a3f5da9d39695
   SwiftyGif: 706c60cf65fa2bc5ee0313beece843c8eb8194d4
 
 PODFILE CHECKSUM: c4c93c5f6502fe2754f48404d3594bf779584011

--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:frontend/admin/providers/admin_provider.dart';
 import 'package:frontend/admin/screens/addMember_screen.dart';
 import 'package:frontend/admin/screens/userInfo_screen.dart';
+import 'package:frontend/providers/projectExperience_provider.dart';
 import 'package:frontend/screens/login_screen.dart';
 import 'package:frontend/screens/settingProFile1_screen.dart';
 import 'package:provider/provider.dart';
@@ -13,6 +14,7 @@ void main() {
     MultiProvider(
       providers: [
         ChangeNotifierProvider(create: (_) => AdminProvider()),
+        ChangeNotifierProvider(create: (_) => ProjectExperienceProvider()),
       ],
       child: const MyApp(),
     ),

--- a/frontend/lib/models/projectExperience_model.dart
+++ b/frontend/lib/models/projectExperience_model.dart
@@ -1,0 +1,44 @@
+class ProjectExperience {
+  String experienceName;
+  String experienceRole;
+  String experienceContent;
+  String experienceGithub;
+  String experienceJob;
+  String experienceDate;
+
+  ProjectExperience({
+    required this.experienceName,
+    required this.experienceRole,
+    required this.experienceContent,
+    required this.experienceGithub,
+    required this.experienceJob,
+    required this.experienceDate,
+  });
+
+  factory ProjectExperience.fromJson(Map<String, dynamic> json) {
+    return ProjectExperience(
+      experienceName: json['experienceName'],
+      experienceRole: json['experienceRole'],
+      experienceContent: json['experienceContent'],
+      experienceGithub: json['experienceGithub'],
+      experienceJob: json['experienceJob'],
+      experienceDate: json['experienceDate'],
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'experienceName': experienceName,
+      'experienceRole': experienceRole,
+      'experienceContent': experienceContent,
+      'experienceGithub': experienceGithub,
+      'experienceJob': experienceJob,
+      'experienceDate': experienceDate,
+    };
+  }
+
+  @override
+  String toString() {
+    return 'experienceName: $experienceName, experienceRole: $experienceRole, experienceContent: $experienceContent, experienceGithub: $experienceGithub, experienceJob: $experienceJob, experienceDate: $experienceDate ';
+  }
+}

--- a/frontend/lib/providers/projectExperience_provider.dart
+++ b/frontend/lib/providers/projectExperience_provider.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:frontend/models/projectExperience_model.dart';
+import 'package:frontend/services/projectExperience_service.dart';
+
+class ProjectExperienceProvider with ChangeNotifier {
+  final ProjectExperienceService service = ProjectExperienceService();
+
+  List<ProjectExperience> projectExperiences =
+      []; // Datatable에 표시할 프로젝트 경험 정보 리스트
+
+  // 프로젝트 경험 정보를 담는 메소드를 호출(그래야만 프로젝트 경험 정보를 projectExperiences에 담고 반환할 수 있음)
+  // projectExperiences 반환
+  Future<List<ProjectExperience>> getProjectExperience() async {
+    return projectExperiences;
+  }
+
+  // 프로젝트 경험 추가
+  Future<void> createProjectExperience(
+      ProjectExperience projectExperience) async {
+    try {
+      await service
+          .createProjectExperience(projectExperience); // 프로젝트 경험 추가 API를 호출
+
+      // 프로젝트 경험 정보 리스트(projectExperiences)에 추가
+      projectExperiences.add(projectExperience);
+      notifyListeners(); // 상태 변경 알림
+    } catch (e) {
+      print(e);
+    }
+  }
+}

--- a/frontend/lib/screens/settingProfile2_screen.dart
+++ b/frontend/lib/screens/settingProfile2_screen.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import 'package:frontend/screens/home_screen.dart';
 import 'package:percent_indicator/linear_percent_indicator.dart';
+import 'package:frontend/models/projectExperience_model.dart';
+import 'package:frontend/providers/projectExperience_provider.dart';
 
 class SettingProfile2Page extends StatefulWidget {
   const SettingProfile2Page({Key? key}) : super(key: key);
@@ -57,46 +60,58 @@ class _SettingProfile2PageState extends State<SettingProfile2Page> {
     setState(() {});
   }
 
-  void _onTapHandler() {
-    setState(() {
-      final projectName = projectNameController.text;
-      final projectExperience = projectExperienceController.text;
-      final githubLink = githubLinkController.text;
-      final roll = rollController.text;
-      final part = partController.text;
+  Future<void> _onTapHandler() async {
+    final projectName = projectNameController.text;
+    final projectExperience = projectExperienceController.text;
+    final githubLink = githubLinkController.text;
+    final roll = rollController.text;
+    final part = partController.text;
 
-      if (projectName.isNotEmpty &&
-          projectExperience.isNotEmpty &&
-          githubLink.isNotEmpty &&
-          roll.isNotEmpty &&
-          part.isNotEmpty &&
-          (selectedDuration != null || customDurationValue.isNotEmpty)) {
-        // 입력 사항이 모두 채워져 있을 때 처리할 로직
-        print('프로젝트 명 : $projectName');
-        print('프로젝트 경험 : $projectExperience');
-        print('깃허브 링크 : $githubLink');
-        print('역할 : $roll');
-        print('맡은 파트 : $part');
-        if (selectedDuration == '직접 입력') {
-          print('직접 입력한 프로젝트 기간 : $customDurationValue');
-        } else {
-          print('프로젝트 기간 : $selectedDuration');
-          customDurationValue = ''; // 선택된 값 초기화
-        }
-        writtenText = true; // 입력 완료 상태로 변경
-        percent = 1; // 100%로 진행률 증가
-
-        // 입력 사항 다 입력하고 '알리미 시작하기' 클릭하면 홈페이지로 이동
-        Navigator.push(
-          context,
-          MaterialPageRoute(
-            builder: (context) => const HomePage(),
-          ),
-        );
+    if (projectName.isNotEmpty &&
+        projectExperience.isNotEmpty &&
+        githubLink.isNotEmpty &&
+        roll.isNotEmpty &&
+        part.isNotEmpty &&
+        (selectedDuration != null || customDurationValue.isNotEmpty)) {
+      // 입력 사항이 모두 채워져 있을 때 처리할 로직
+      print('프로젝트 명 : $projectName');
+      print('프로젝트 경험 : $projectExperience');
+      print('깃허브 링크 : $githubLink');
+      print('역할 : $roll');
+      print('맡은 파트 : $part');
+      if (selectedDuration == '직접 입력') {
+        print('직접 입력한 프로젝트 기간 : $customDurationValue');
       } else {
-        print('입력 사항을 모두 작성해주세요.');
+        print('프로젝트 기간 : $selectedDuration');
+        customDurationValue = ''; // 선택된 값 초기화
       }
-    });
+      writtenText = true; // 입력 완료 상태로 변경
+      percent = 1; // 100%로 진행률 증가
+
+      // ProjectExperience 인스턴스 생성
+      ProjectExperience newExperience = ProjectExperience(
+        experienceName: projectName,
+        experienceRole: roll,
+        experienceContent: projectExperience,
+        experienceGithub: githubLink, // 깃허브 링크 설정
+        experienceJob: part,
+        experienceDate: selectedDuration ?? customDurationValue,
+      );
+
+      // Provider를 사용하여 API 호출
+      final provider = context.read<ProjectExperienceProvider>();
+      await provider.createProjectExperience(newExperience);
+
+      // 홈 페이지로 이동
+      Navigator.push(
+        context,
+        MaterialPageRoute(
+          builder: (context) => const HomePage(),
+        ),
+      );
+    } else {
+      print('입력 사항을 모두 작성해주세요.');
+    }
   }
 
   @override
@@ -165,7 +180,7 @@ class _SettingProfile2PageState extends State<SettingProfile2Page> {
                     TextFormField(
                       controller: rollController,
                       decoration: const InputDecoration(
-                        labelText: '나의 역할(팀장, 팀원)을 입력해주세요',
+                        labelText: '나의 역할(LEADER, MEMBER)를 입력해주세요',
                         labelStyle: TextStyle(
                           fontSize: 12,
                           color: Color(0xFF808080),
@@ -221,7 +236,7 @@ class _SettingProfile2PageState extends State<SettingProfile2Page> {
                           fontSize: 12,
                           color: Color(0xFF808080),
                         ),
-                        prefixText: 'github.com/',
+                        prefixText: 'https://github.com/',
                         prefixStyle: TextStyle(
                           fontSize: 12,
                           color: Colors.black,

--- a/frontend/lib/screens/settingProfile2_screen.dart
+++ b/frontend/lib/screens/settingProfile2_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:frontend/screens/home_screen.dart';
 import 'package:percent_indicator/linear_percent_indicator.dart';
 
 class SettingProfile2Page extends StatefulWidget {
@@ -84,6 +85,14 @@ class _SettingProfile2PageState extends State<SettingProfile2Page> {
         }
         writtenText = true; // 입력 완료 상태로 변경
         percent = 1; // 100%로 진행률 증가
+
+        // 입력 사항 다 입력하고 '알리미 시작하기' 클릭하면 홈페이지로 이동
+        Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder: (context) => const HomePage(),
+          ),
+        );
       } else {
         print('입력 사항을 모두 작성해주세요.');
       }

--- a/frontend/lib/screens/settingProfile_screen.dart
+++ b/frontend/lib/screens/settingProfile_screen.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:badges/badges.dart' as badges;
-import 'package:frontend/screens/home_screen.dart';
+import 'package:frontend/screens/settingProfile2_screen.dart';
 import 'package:percent_indicator/percent_indicator.dart';
 
 class SettingProfilePage extends StatefulWidget {
@@ -384,7 +384,7 @@ class _SettingProfilePageState extends State<SettingProfilePage> {
                       Navigator.push(
                         context,
                         MaterialPageRoute(
-                          builder: (context) => const HomePage(),
+                          builder: (context) => const SettingProfile2Page(),
                         ),
                       );
                     }

--- a/frontend/lib/services/projectExperience_service.dart
+++ b/frontend/lib/services/projectExperience_service.dart
@@ -1,0 +1,41 @@
+import 'dart:convert';
+import 'package:frontend/models/projectExperience_model.dart';
+import 'package:http/http.dart' as http;
+import 'package:shared_preferences/shared_preferences.dart';
+
+class ProjectExperienceService {
+  Future<String?> getToken() async {
+    SharedPreferences prefs = await SharedPreferences.getInstance();
+    return prefs.getString('accessToken'); // accessToken 키로 저장된 문자열 값을 가져옴
+  }
+
+  // 프로젝트 경험 추가 API
+  Future<void> createProjectExperience(
+      ProjectExperience projectExperience) async {
+    const String baseUrl =
+        'https://reminder.sungkyul.ac.kr/api/v1/member-experience';
+
+    final token = await getToken();
+    if (token == null) {
+      throw Exception('No access token found: $token');
+    }
+
+    final response = await http.post(
+      Uri.parse(baseUrl),
+      headers: <String, String>{
+        'Content-Type': 'application/json',
+        'access': token,
+      },
+      body: jsonEncode(projectExperience.toJson()), // 인스턴스를 사용하여 toJson 메서드를 호출
+    );
+
+    if (response.statusCode == 200) {
+      // 성공 처리
+      print('프로젝트 경험 추가 성공');
+      print('프로젝트 경험 목록: ${utf8.decode(response.bodyBytes)}');
+    } else {
+      // 실패 처리
+      throw Exception('프로젝트 경험 추가 실패: ${utf8.decode(response.bodyBytes)}');
+    }
+  }
+}


### PR DESCRIPTION
## 📌 관련 이슈
#91 

## ✨ 코드 변경 내용
- ProjectExperience 모델 생성
- Datatable에 표시할 프로젝트 경험 정보 리스트 projectExperiences 배열 선언하여 관리
- 프로젝트 경험 추가 시 ProjectExperienceProvider 호출
- notifyListeners 매서드 사용하여 상태 변경 알림 적용

## 📸 스크린샷(선택)
<img width="745" alt="스크린샷 2024-07-16 오후 12 56 44" src="https://github.com/user-attachments/assets/0ed3a53d-7de3-405a-a346-efff1f34e777">
<img width="1193" alt="스크린샷 2024-07-16 오후 12 57 35" src="https://github.com/user-attachments/assets/c61238ac-576e-4f86-bca6-b40a27b5877a">
<img width="748" alt="스크린샷 2024-07-16 오후 12 58 26" src="https://github.com/user-attachments/assets/963a0f28-a75c-4311-aed5-e3ee90098d51">


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
