### PR TITLE
[Fix/#95] 로그인 관련 페이지 이동 코드 수정

### DIFF
--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -3,8 +3,10 @@ import 'package:frontend/admin/providers/admin_provider.dart';
 import 'package:frontend/admin/screens/addMember_screen.dart';
 import 'package:frontend/admin/screens/userInfo_screen.dart';
 import 'package:frontend/providers/projectExperience_provider.dart';
+import 'package:frontend/screens/home_screen.dart';
 import 'package:frontend/screens/login_screen.dart';
 import 'package:frontend/screens/settingProFile1_screen.dart';
+import 'package:frontend/screens/settingProfile2_screen.dart';
 import 'package:provider/provider.dart';
 import 'package:frontend/services/login_services.dart';
 
@@ -60,6 +62,8 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
         '/add_member': (context) => const AddMemberPage(),
         '/user-info': (context) => const UserInfoPage(),
         '/setting-profile': (context) => const SettingProfile1Page(),
+        '/member-experience': (context) => const SettingProfile2Page(),
+        '/homepage': (context) => const HomePage(),
       },
     );
   }

--- a/frontend/lib/screens/login_screen.dart
+++ b/frontend/lib/screens/login_screen.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:frontend/screens/settingProFile1_screen.dart';
 import 'package:frontend/services/login_services.dart';
 import 'package:http/http.dart' as http;
 import 'package:cookie_jar/cookie_jar.dart';
@@ -83,13 +82,20 @@ class _LoginPageState extends State<LoginPage> {
         await againToken(); // 토큰 재발급 시도
       } else {
         print('유효한 토큰이 존재합니다.');
-        Navigator.pushReplacement(
-          context,
-          MaterialPageRoute(
-            builder: (context) => const SettingProfile1Page(),
-          ),
-        );
+        final userRole = prefs.getString('userRole');
+        if (userRole != null) {
+          _navigateBasedOnRole(userRole);
+        }
       }
+    }
+  }
+
+  // 역할에 따라 페이지로 이동하는 함수
+  void _navigateBasedOnRole(String role) {
+    if (role == 'ROLE_ADMIN') {
+      Navigator.pushReplacementNamed(context, '/user-info');
+    } else if (role == 'ROLE_USER') {
+      Navigator.pushReplacementNamed(context, '/homepage');
     }
   }
 
@@ -101,7 +107,7 @@ class _LoginPageState extends State<LoginPage> {
     await cookieJar.deleteAll(); // 쿠키 삭제
   }
 
-  // 토큰 재발급 API
+  // 토큰 재발급 API(자동 로그인 체크 시)
   Future<void> againToken() async {
     try {
       final prefs = await SharedPreferences.getInstance();
@@ -144,13 +150,11 @@ class _LoginPageState extends State<LoginPage> {
         }
 
         print('토큰 재발급 성공!');
-        // 토큰 재발급 성공 시
-        Navigator.pushReplacement(
-          context,
-          MaterialPageRoute(
-            builder: (context) => const SettingProfile1Page(),
-          ),
-        );
+        // 토큰 재발급 성공 시 역할에 따라 페이지로 이동
+        final userRole = prefs.getString('userRole');
+        if (userRole != null) {
+          _navigateBasedOnRole(userRole);
+        }
       } else {
         print('토큰 재발급 실패: ${response.statusCode} ${response.body}');
       }
@@ -352,6 +356,8 @@ class _LoginPageState extends State<LoginPage> {
                             Navigator.pushNamed(context, '/homepage');
                           }
                         }
+                        // userRole 저장
+                        await prefs.setString('userRole', result['role']);
                       } else {
                         // 로그인 실패 처리
                       }

--- a/frontend/lib/screens/login_screen.dart
+++ b/frontend/lib/screens/login_screen.dart
@@ -1,7 +1,4 @@
-import 'dart:convert';
-
 import 'package:flutter/material.dart';
-import 'package:frontend/screens/home_screen.dart';
 import 'package:frontend/screens/settingProFile1_screen.dart';
 import 'package:frontend/services/login_services.dart';
 import 'package:http/http.dart' as http;
@@ -27,8 +24,7 @@ class _LoginPageState extends State<LoginPage> {
 
   final formKey = GlobalKey<FormState>(); // 폼 유효성을 검사하는데 사용
 
-  // 로그인 및 토큰 재발급을 위한 서버 주소 상수
-  static const loginAddress = 'https://reminder.sungkyul.ac.kr/login';
+  // 토큰 재발급을 위한 서버 주소 상수
   static const tokenRefreshAddress =
       'https://reminder.sungkyul.ac.kr/api/v1/reissue';
 
@@ -160,100 +156,6 @@ class _LoginPageState extends State<LoginPage> {
       }
     } catch (e) {
       print('토큰 재발급 요청 중 에러 발생: ${e.toString()}');
-    }
-  }
-
-  // 로그인 API
-  Future<void> handleLogin(String studentId, String password) async {
-    try {
-      final url = Uri.parse(loginAddress);
-
-      // HTTP POST 요청 전송
-      final response = await http.post(
-        url,
-        body: {
-          'studentId': studentId,
-          'password': password,
-        },
-      );
-
-      print('로그인 응답 상태 코드: ${response.statusCode}');
-      print('로그인 응답 본문: ${response.body}');
-
-      if (response.statusCode == 200) {
-        final responseData = jsonDecode(response.body);
-        final userRole = responseData['userRole'];
-        final techStack = responseData['techStack'];
-
-        final accessToken = response.headers['access']; // 액세스 토큰 추출
-        final setCookieHeader = response.headers['set-cookie'];
-        final refreshToken = setCookieHeader != null
-            ? extractRefreshToken(setCookieHeader)
-            : null;
-
-        final prefs = await SharedPreferences.getInstance();
-        if (accessToken != null && refreshToken != null) {
-          // 이전 토큰 삭제
-          await clearTokens();
-
-          // 새 토큰 저장
-          await prefs.setString('accessToken', accessToken); // 액세스 토큰 저장
-          await prefs.setString('refreshToken', refreshToken); // 리프레시 토큰 저장
-
-          // 자동 로그인 상태 저장
-          await prefs.setBool('isAutoLogin', isAutoLogin);
-          if (isAutoLogin) {
-            // 자동 로그인 체크 시에만 학번과 비밀번호 저장
-            await prefs.setString('studentId', studentId);
-            await prefs.setString('password', password);
-          } else {
-            // 체크 해제 시 저장된 학번과 비밀번호 삭제
-            await prefs.remove('studentId');
-            await prefs.remove('password');
-          }
-
-          final uri = Uri.parse(loginAddress);
-          cookieJar.saveFromResponse(
-              uri, [Cookie('refreshToken', refreshToken)]); // 쿠키 저장
-
-          // 저장된 토큰 로그로 확인
-          final savedAccessToken = prefs.getString('accessToken');
-          final savedRefreshToken = prefs.getString('refreshToken');
-          print('저장된 액세스 토큰: $savedAccessToken');
-          print('저장된 리프레시 토큰: $savedRefreshToken');
-        }
-        print('로그인 성공');
-
-        if (userRole == 'ROLE_ADMIN') {
-          Navigator.pushNamed(
-            context,
-            '/user-info',
-          );
-        } else if (userRole == 'ROLE_USER') {
-          if (context.mounted) {
-            if (techStack != null && techStack.isNotEmpty) {
-              // isNotEmpty를 호출하기 전에 해당 변수가 null인지 확인해야 함
-              Navigator.pushReplacement(
-                context,
-                MaterialPageRoute(
-                  builder: (context) => const HomePage(),
-                ),
-              );
-            } else {
-              Navigator.pushReplacement(
-                context,
-                MaterialPageRoute(
-                  builder: (context) => const SettingProfile1Page(),
-                ),
-              );
-            }
-          }
-        }
-      } else {
-        print('로그인 실패: ${response.statusCode} ${response.body}');
-      }
-    } catch (e) {
-      print('로그인 요청 중 에러 발생: ${e.toString()}');
     }
   }
 
@@ -417,7 +319,6 @@ class _LoginPageState extends State<LoginPage> {
               ),
               const SizedBox(height: 27),
 
-              // 로그인 버튼
               ElevatedButton(
                 onPressed: () {
                   // 유효성 통과 시 홈 화면으로 이동
@@ -438,7 +339,18 @@ class _LoginPageState extends State<LoginPage> {
                         if (result['role'] == 'ROLE_ADMIN') {
                           Navigator.pushNamed(context, '/user-info');
                         } else if (result['role'] == 'ROLE_USER') {
-                          Navigator.pushNamed(context, '/setting-profile');
+                          // techStack 값이 null이거나 값이 비어있는 경우
+                          if (result['techStack'] == null ||
+                              result['techStack'].isEmpty) {
+                            Navigator.pushNamed(context, '/setting-profile');
+                            // memberExperience 값이 null이거나 값이 비어있는 경우
+                          } else if (result['memberExperiences'] == null ||
+                              result['memberExperiences'].isEmpty) {
+                            Navigator.pushNamed(context, '/member-experience');
+                          } else {
+                            // techStack, memberExperiences 값이 둘 다 채워진 경우
+                            Navigator.pushNamed(context, '/homepage');
+                          }
                         }
                       } else {
                         // 로그인 실패 처리
@@ -464,25 +376,6 @@ class _LoginPageState extends State<LoginPage> {
               ),
             ],
           ),
-        ),
-      ),
-    );
-  }
-
-  // 아이디 / 비밀번호 찾기 텍스트 버튼
-  Widget idAndPwTextBtn(String title) {
-    return TextButton(
-      onPressed: () {},
-      style: TextButton.styleFrom(
-        minimumSize: Size.zero,
-        padding: EdgeInsets.zero,
-        tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-      ),
-      child: Text(
-        title,
-        style: const TextStyle(
-          fontWeight: FontWeight.bold,
-          color: Color(0xFF808080),
         ),
       ),
     );

--- a/frontend/lib/screens/settingProFile1_screen.dart
+++ b/frontend/lib/screens/settingProFile1_screen.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:badges/badges.dart' as badges;
-import 'package:frontend/providers/profile_provider.dart';
 import 'package:frontend/screens/settingProfile_screen.dart';
 import 'package:percent_indicator/linear_percent_indicator.dart';
 

--- a/frontend/lib/services/login_services.dart
+++ b/frontend/lib/services/login_services.dart
@@ -162,6 +162,8 @@ class LoginAPI {
       if (response.statusCode == 200) {
         final responseData = jsonDecode(response.body);
         final userRole = responseData['userRole'];
+        final techStack = responseData['techStack'];
+        final memberExperience = responseData['memberExperiences'];
 
         final accessToken = response.headers['access']; // 액세스 토큰 추출
         final setCookieHeader = response.headers['set-cookie'];
@@ -193,6 +195,8 @@ class LoginAPI {
         return {
           'success': true,
           'role': userRole,
+          'techStack': techStack,
+          'memberExperiences': memberExperience,
         };
       } else {
         print('로그인 실패: ${response.statusCode} ${response.body}');


### PR DESCRIPTION
## 📌 관련 이슈
#95

## ✨ 코드 변경 내용
[ 로그인 시 적용 ]
- techStack 값이 null이거나 값이 비어있는 경우 SettingProfile1Page로 이동되도록 구현
- memberExperience 값이 null이거나 값이 비어있는 경우 SettingProfile2Page로 이동되도록 구현
- techStack, memberExperiences 값이 둘 다 채워진 경우 HomePage로 이동되도록 구현

[ 앱 종료 시 ]
- userRole 값을 getString으로 가져옴
- 앱 종료 후 다시 접속할 때 가져온 userRole 값에 따라 처음 보이는 화면 다르게 설정
- 토큰 재발급 API 호출되어 성공 되었을 때도 마찬가지로 적용

## 📸 스크린샷(선택)
- 용량이 너무 커 사진 캡쳐로 대체하겠습니다
<img width="1800" alt="스크린샷 2024-07-17 오전 11 54 19" src="https://github.com/user-attachments/assets/c2f6c0a7-fb18-4e33-b29e-5417402398a9">
<img width="1800" alt="스크린샷 2024-07-17 오후 12 47 06" src="https://github.com/user-attachments/assets/7d5bce34-62d9-47ee-b5da-09fdd89ff6b0">


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
