### PR TITLE
[feat : # 97] 프로젝트 경험 여러개 추가 API 연동

### DIFF
--- a/frontend/lib/providers/projectExperience_provider.dart
+++ b/frontend/lib/providers/projectExperience_provider.dart
@@ -28,4 +28,19 @@ class ProjectExperienceProvider with ChangeNotifier {
       print(e);
     }
   }
+
+  // 프로젝트 경험 여러개 추가
+  Future<void> createProjectExperiences(
+      List<ProjectExperience> projectExperienceList) async {
+    try {
+      await service.createProjectExperiences(
+          projectExperienceList); // 프로젝트 경험 여러 개 추가 API를 호출
+
+      // 프로젝트 경험 정보 리스트(projectExperiences)에 추가
+      projectExperiences.addAll(projectExperienceList);
+      notifyListeners(); // 상태 변경 알림
+    } catch (e) {
+      print(e);
+    }
+  }
 }

--- a/frontend/lib/services/projectExperience_service.dart
+++ b/frontend/lib/services/projectExperience_service.dart
@@ -38,4 +38,36 @@ class ProjectExperienceService {
       throw Exception('프로젝트 경험 추가 실패: ${utf8.decode(response.bodyBytes)}');
     }
   }
+
+  // 프로젝트 경험 여러개 추가 API
+  Future<void> createProjectExperiences(
+      List<ProjectExperience> projectExperiences) async {
+    const String baseUrl =
+        'https://reminder.sungkyul.ac.kr/api/v1/member-experience/list';
+
+    final token = await getToken();
+    if (token == null) {
+      throw Exception('No access token found: $token');
+    }
+
+    final response = await http.post(
+      Uri.parse(baseUrl),
+      headers: <String, String>{
+        'Content-Type': 'application/json',
+        'access': token,
+      },
+      body: jsonEncode(projectExperiences // ProjectExperience 객체의 리스트
+          .map((e) => e.toJson()) // toJson 메서드를 호출하여 해당 객체를 JSON으로 변환
+          .toList()), // JSON -> List 형식으로 변환
+    );
+
+    if (response.statusCode == 200) {
+      // 성공 처리
+      print('프로젝트 경험 여러 개 추가 성공');
+      print('프로젝트 경험 목록: ${utf8.decode(response.bodyBytes)}');
+    } else {
+      // 실패 처리
+      throw Exception('프로젝트 경험 여러 개 추가 실패: ${utf8.decode(response.bodyBytes)}');
+    }
+  }
 }


### PR DESCRIPTION
## 📌 관련 이슈
#97 

## ✨ 코드 변경 내용
- ProjectExperience 모델 사용하여 List 형식으로 나열되도록 구현
- toJson 메서드를 호출하여 해당 객체를 JSON으로 변환하고 toList 형식으로 변환하여 받음
- 프로젝트 경험 여러개 추가 시 ProjectExperienceProvider 호출
- notifyListeners 매서드 사용하여 상태 변경 알림 적용

## 📸 스크린샷(선택)
<img width="1800" alt="스크린샷 2024-07-17 오후 1 17 56" src="https://github.com/user-attachments/assets/cfd33107-fa53-4f59-8224-be62e50890c9">
<img width="1398" alt="스크린샷 2024-07-17 오후 1 17 46" src="https://github.com/user-attachments/assets/2ccc2870-04ec-4529-966f-c3132f308234">
<img width="749" alt="스크린샷 2024-07-17 오후 1 16 37" src="https://github.com/user-attachments/assets/6fa94e7a-e040-4ee4-8e9b-c3d2b6c8afb8">


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
