### PR TITLE
[Feat/#99] 내 프로젝트 경험 조회 API 연동

### DIFF
--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -64,7 +64,10 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
         '/user-info': (context) => const UserInfoPage(),
         '/setting-profile': (context) => const SettingProfile1Page(),
         '/member-experience': (context) => const SettingProfile2Page(),
-        '/experience': (context) => const ExperiencePage(experiences: []),
+        '/experience': (context) => const ExperiencePage(
+              experiences: [],
+              name: '',
+            ),
         '/homepage': (context) => const HomePage(),
       },
     );

--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -3,8 +3,10 @@ import 'package:frontend/admin/providers/admin_provider.dart';
 import 'package:frontend/admin/screens/addMember_screen.dart';
 import 'package:frontend/admin/screens/userInfo_screen.dart';
 import 'package:frontend/providers/projectExperience_provider.dart';
+import 'package:frontend/screens/experience_screen.dart';
 import 'package:frontend/screens/home_screen.dart';
 import 'package:frontend/screens/login_screen.dart';
+import 'package:frontend/screens/myUserPage_screen.dart';
 import 'package:frontend/screens/settingProFile1_screen.dart';
 import 'package:frontend/screens/settingProfile2_screen.dart';
 import 'package:provider/provider.dart';
@@ -58,11 +60,12 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
     return MaterialApp(
       initialRoute: '/',
       routes: {
-        '/': (context) => const LoginPage(),
+        '/': (context) => const MyUserPage(),
         '/add_member': (context) => const AddMemberPage(),
         '/user-info': (context) => const UserInfoPage(),
         '/setting-profile': (context) => const SettingProfile1Page(),
         '/member-experience': (context) => const SettingProfile2Page(),
+        '/experience': (context) => const ExperiencePage(),
         '/homepage': (context) => const HomePage(),
       },
     );

--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -6,7 +6,6 @@ import 'package:frontend/providers/projectExperience_provider.dart';
 import 'package:frontend/screens/experience_screen.dart';
 import 'package:frontend/screens/home_screen.dart';
 import 'package:frontend/screens/login_screen.dart';
-import 'package:frontend/screens/myUserPage_screen.dart';
 import 'package:frontend/screens/settingProFile1_screen.dart';
 import 'package:frontend/screens/settingProfile2_screen.dart';
 import 'package:provider/provider.dart';
@@ -60,12 +59,12 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
     return MaterialApp(
       initialRoute: '/',
       routes: {
-        '/': (context) => const MyUserPage(),
+        '/': (context) => const LoginPage(),
         '/add_member': (context) => const AddMemberPage(),
         '/user-info': (context) => const UserInfoPage(),
         '/setting-profile': (context) => const SettingProfile1Page(),
         '/member-experience': (context) => const SettingProfile2Page(),
-        '/experience': (context) => const ExperiencePage(),
+        '/experience': (context) => const ExperiencePage(experiences: []),
         '/homepage': (context) => const HomePage(),
       },
     );

--- a/frontend/lib/providers/projectExperience_provider.dart
+++ b/frontend/lib/providers/projectExperience_provider.dart
@@ -43,4 +43,20 @@ class ProjectExperienceProvider with ChangeNotifier {
       print(e);
     }
   }
+
+  // 내 프로젝트 경험 조회
+  Future<void> fetchExperiences() async {
+    try {
+      // ProjectExperienceService의 인스턴스를 통해 프로젝트 경험 정보를 가져옴
+      List<ProjectExperience> fetchExperiences =
+          await service.fetchExperiences();
+
+      // fetchExperiences 매서드로 가져온 프로젝트 경험 정보를 projectExperiences 리스트에 할당
+      projectExperiences = fetchExperiences;
+
+      notifyListeners(); // 상태 변경을 알림
+    } catch (e) {
+      print(e);
+    }
+  }
 }

--- a/frontend/lib/screens/experience_screen.dart
+++ b/frontend/lib/screens/experience_screen.dart
@@ -3,21 +3,24 @@ import 'package:frontend/models/projectExperience_model.dart';
 
 class ExperiencePage extends StatefulWidget {
   final List<ProjectExperience> experiences;
+  final String name;
 
-  const ExperiencePage({required this.experiences, super.key});
+  const ExperiencePage({
+    required this.experiences,
+    required this.name,
+    super.key,
+  });
 
   @override
   ExperiencePageState createState() => ExperiencePageState();
 }
 
 class ExperiencePageState extends State<ExperiencePage> {
-  // 각 ExpansionTile의 확장 상태를 저장하는 리스트
   late List<bool> _isExpanded;
 
   @override
   void initState() {
     super.initState();
-    // 각 경험 항목의 초기 확장 상태를 false로 설정
     _isExpanded = List<bool>.filled(widget.experiences.length, false);
   }
 
@@ -59,9 +62,9 @@ class ExperiencePageState extends State<ExperiencePage> {
           children: [
             Row(
               children: [
-                const Text(
-                  '✨소진수의 빛나는 경험✨',
-                  style: TextStyle(
+                Text(
+                  '✨${widget.name}의 빛나는 경험✨',
+                  style: const TextStyle(
                     fontSize: 20,
                     fontWeight: FontWeight.bold,
                   ),

--- a/frontend/lib/screens/experience_screen.dart
+++ b/frontend/lib/screens/experience_screen.dart
@@ -1,13 +1,11 @@
 import 'package:flutter/material.dart';
+import 'package:frontend/models/projectExperience_model.dart';
 
-class ExperiencePage extends StatefulWidget {
-  const ExperiencePage({super.key});
+class ExperiencePage extends StatelessWidget {
+  final List<ProjectExperience> experiences;
 
-  @override
-  State<ExperiencePage> createState() => _ExperiencePageState();
-}
+  const ExperiencePage({required this.experiences, super.key});
 
-class _ExperiencePageState extends State<ExperiencePage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -45,37 +43,61 @@ class _ExperiencePageState extends State<ExperiencePage> {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             const Text(
-              '✨(이름)의 빛나는 경험✨',
+              '✨소진수의 빛나는 경험✨',
               style: TextStyle(
                 fontSize: 20,
                 fontWeight: FontWeight.bold,
               ),
             ),
             const SizedBox(height: 20),
-            ExpansionTile(
-              title: userInfo(
-                  title: '프로젝트명',
-                  titleSize: 20,
-                  info: '음식점 사장님들을 위한 chatGPT를 이용한 AI 기반 운영꿀팁 다이닝 어플리케이션'),
-              children: [
-                Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 20.0),
-                  child: Column(
+            Expanded(
+              child: ListView.builder(
+                itemCount: experiences.length,
+                itemBuilder: (context, index) {
+                  final experience = experiences[index];
+                  return ExpansionTile(
+                    title: userInfo(
+                      title: '프로젝트명',
+                      titleSize: 20,
+                      info: experience.experienceName,
+                    ),
                     children: [
-                      userInfo(title: '나의 역할', titleSize: 18, info: '팀장'),
-                      userInfo(
-                          title: '프로젝트 경험',
-                          titleSize: 18,
-                          info: '프로젝트 경험에 대한 것...'),
-                      userInfo(
-                          title: '깃허브 프로젝트 링크',
-                          titleSize: 18,
-                          info: 'https://github.com/Jeong-Reminder/'),
-                      userInfo(title: '프로젝트 기간', titleSize: 18, info: '1개월'),
+                      Padding(
+                        padding: const EdgeInsets.symmetric(horizontal: 20.0),
+                        child: Column(
+                          children: [
+                            userInfo(
+                              title: '나의 역할',
+                              titleSize: 18,
+                              info: experience.experienceRole,
+                            ),
+                            userInfo(
+                              title: '프로젝트 경험',
+                              titleSize: 18,
+                              info: experience.experienceContent,
+                            ),
+                            userInfo(
+                              title: '깃허브 프로젝트 링크',
+                              titleSize: 18,
+                              info: experience.experienceGithub,
+                            ),
+                            userInfo(
+                              title: '직무',
+                              titleSize: 18,
+                              info: experience.experienceJob,
+                            ),
+                            userInfo(
+                              title: '프로젝트 기간',
+                              titleSize: 18,
+                              info: experience.experienceDate,
+                            ),
+                          ],
+                        ),
+                      ),
                     ],
-                  ),
-                ),
-              ],
+                  );
+                },
+              ),
             ),
           ],
         ),

--- a/frontend/lib/screens/experience_screen.dart
+++ b/frontend/lib/screens/experience_screen.dart
@@ -1,10 +1,25 @@
 import 'package:flutter/material.dart';
 import 'package:frontend/models/projectExperience_model.dart';
 
-class ExperiencePage extends StatelessWidget {
+class ExperiencePage extends StatefulWidget {
   final List<ProjectExperience> experiences;
 
   const ExperiencePage({required this.experiences, super.key});
+
+  @override
+  ExperiencePageState createState() => ExperiencePageState();
+}
+
+class ExperiencePageState extends State<ExperiencePage> {
+  // 각 ExpansionTile의 확장 상태를 저장하는 리스트
+  late List<bool> _isExpanded;
+
+  @override
+  void initState() {
+    super.initState();
+    // 각 경험 항목의 초기 확장 상태를 false로 설정
+    _isExpanded = List<bool>.filled(widget.experiences.length, false);
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -42,58 +57,100 @@ class ExperiencePage extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            const Text(
-              '✨소진수의 빛나는 경험✨',
-              style: TextStyle(
-                fontSize: 20,
-                fontWeight: FontWeight.bold,
-              ),
+            Row(
+              children: [
+                const Text(
+                  '✨소진수의 빛나는 경험✨',
+                  style: TextStyle(
+                    fontSize: 20,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                const SizedBox(width: 10),
+                const Spacer(),
+                Visibility(
+                  visible: _isExpanded.contains(true),
+                  child: GestureDetector(
+                    onTap: () {},
+                    child: Container(
+                      height: 20,
+                      width: 100,
+                      margin: const EdgeInsets.only(left: 10),
+                      decoration: BoxDecoration(
+                        color: const Color(0xFF2A72E7),
+                        borderRadius: BorderRadius.circular(6),
+                      ),
+                      child: const Center(
+                        child: Text(
+                          '경험 수정하기',
+                          style: TextStyle(
+                            fontSize: 10,
+                            fontWeight: FontWeight.bold,
+                            color: Colors.white,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ],
             ),
             const SizedBox(height: 20),
             Expanded(
               child: ListView.builder(
-                itemCount: experiences.length,
+                itemCount: widget.experiences.length,
                 itemBuilder: (context, index) {
-                  final experience = experiences[index];
-                  return ExpansionTile(
-                    title: userInfo(
-                      title: '프로젝트명',
-                      titleSize: 20,
-                      info: experience.experienceName,
-                    ),
+                  final experience = widget.experiences[index];
+                  return Column(
                     children: [
-                      Padding(
-                        padding: const EdgeInsets.symmetric(horizontal: 20.0),
-                        child: Column(
-                          children: [
-                            userInfo(
-                              title: '나의 역할',
-                              titleSize: 18,
-                              info: experience.experienceRole,
-                            ),
-                            userInfo(
-                              title: '프로젝트 경험',
-                              titleSize: 18,
-                              info: experience.experienceContent,
-                            ),
-                            userInfo(
-                              title: '깃허브 프로젝트 링크',
-                              titleSize: 18,
-                              info: experience.experienceGithub,
-                            ),
-                            userInfo(
-                              title: '직무',
-                              titleSize: 18,
-                              info: experience.experienceJob,
-                            ),
-                            userInfo(
-                              title: '프로젝트 기간',
-                              titleSize: 18,
-                              info: experience.experienceDate,
-                            ),
-                          ],
+                      ExpansionTile(
+                        title: userInfo(
+                          title: '프로젝트명',
+                          titleSize: 20,
+                          info: experience.experienceName,
                         ),
+                        onExpansionChanged: (bool expanded) {
+                          setState(() {
+                            _isExpanded[index] = expanded;
+                          });
+                        },
+                        children: [
+                          Padding(
+                            padding:
+                                const EdgeInsets.symmetric(horizontal: 20.0),
+                            child: Column(
+                              children: [
+                                userInfo(
+                                  title: '나의 역할',
+                                  titleSize: 18,
+                                  info: experience.experienceRole,
+                                ),
+                                userInfo(
+                                  title: '프로젝트 경험',
+                                  titleSize: 18,
+                                  info: experience.experienceContent,
+                                ),
+                                userInfo(
+                                  title: '깃허브 프로젝트 링크',
+                                  titleSize: 18,
+                                  info: experience.experienceGithub,
+                                ),
+                                userInfo(
+                                  title: '직무',
+                                  titleSize: 18,
+                                  info: experience.experienceJob,
+                                ),
+                                userInfo(
+                                  title: '프로젝트 기간',
+                                  titleSize: 18,
+                                  info: experience.experienceDate,
+                                ),
+                              ],
+                            ),
+                          ),
+                        ],
                       ),
+                      const SizedBox(height: 10),
                     ],
                   );
                 },
@@ -106,10 +163,11 @@ class ExperiencePage extends StatelessWidget {
   }
 
   // 회원 정보 위젯
-  Widget userInfo(
-      {required String title,
-      required double titleSize,
-      required String info}) {
+  Widget userInfo({
+    required String title,
+    required double titleSize,
+    required String info,
+  }) {
     return Column(
       children: [
         ListTile(

--- a/frontend/lib/screens/home_screen.dart
+++ b/frontend/lib/screens/home_screen.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
-import 'package:frontend/screens/myOwnerPage_screen.dart';
+import 'package:frontend/screens/myUserPage_screen.dart';
 import 'package:table_calendar/table_calendar.dart';
 
 class HomePage extends StatefulWidget {
@@ -212,7 +211,7 @@ class _HomePageState extends State<HomePage> {
                   Navigator.push(
                     context,
                     MaterialPageRoute(
-                      builder: (context) => const MyOwnerPage(),
+                      builder: (context) => const MyUserPage(),
                     ),
                   );
                 },

--- a/frontend/lib/screens/myUserPage_screen.dart
+++ b/frontend/lib/screens/myUserPage_screen.dart
@@ -138,7 +138,9 @@ class _MyUserPageState extends State<MyUserPage> {
         leading: Padding(
           padding: const EdgeInsets.only(left: 12.0),
           child: IconButton(
-            onPressed: () {},
+            onPressed: () {
+              Navigator.pushNamed(context, '/homepage');
+            },
             icon: Image.asset('assets/images/logo.png'),
             color: Colors.black,
           ),
@@ -188,7 +190,7 @@ class _MyUserPageState extends State<MyUserPage> {
               // 프로필
               const Profile(
                 profileUrl: 'assets/images/profile.png',
-                name: '민택기',
+                name: '소진수',
                 showSubTitle: true,
                 showExperienceButton: true, // 내 경험 보러가기
               ),

--- a/frontend/lib/screens/myUserPage_screen.dart
+++ b/frontend/lib/screens/myUserPage_screen.dart
@@ -190,6 +190,7 @@ class _MyUserPageState extends State<MyUserPage> {
                 profileUrl: 'assets/images/profile.png',
                 name: '민택기',
                 showSubTitle: true,
+                showExperienceButton: true, // 내 경험 보러가기
               ),
 
               const SizedBox(height: 25),

--- a/frontend/lib/screens/myUserPage_screen.dart
+++ b/frontend/lib/screens/myUserPage_screen.dart
@@ -15,19 +15,23 @@ class MyUserPage extends StatefulWidget {
 class _MyUserPageState extends State<MyUserPage> {
   bool isExpanded = false; // 내 팀 현황 확장성 여부를 나타내는 변수
   String? studentId = ''; // 학번을 저장할 변수, 기본 값을 빈 문자열로 설정
+  String? name = ''; // 이름을 저장할 변수, 기본 값을 빈 문자열로 설정
+  String? status = ''; // 상태를 저장할 변수, 기본 값을 빈 문자열로 설정
 
   @override
   void initState() {
     super.initState();
-    _loadStudentId(); // 학번을 로드하는 메서드 호출
+    _loadCredentials(); // 학번을 로드하는 메서드 호출
   }
 
-  // 학번을 로드하는 메서드
-  Future<void> _loadStudentId() async {
+  // 학번, 이름, 재적상태를 로드하는 메서드
+  Future<void> _loadCredentials() async {
     final loginAPI = LoginAPI(); // LoginAPI 인스턴스 생성
     final credentials = await loginAPI.loadCredentials(); // 저장된 자격증명 로드
     setState(() {
       studentId = credentials['studentId'] ?? ''; // 학번 설정, 없으면 빈 문자열로 설정
+      name = credentials['name'] ?? ''; // 이름 설정, 없으면 빈 문자열로 설정
+      status = credentials['status'] ?? ''; // 상태 설정, 없으면 빈 문자열로 설정
     });
   }
 
@@ -209,10 +213,11 @@ class _MyUserPageState extends State<MyUserPage> {
               // 프로필
               Profile(
                 profileUrl: 'assets/images/profile.png',
-                name: '소진수',
+                name: name ?? '', // 이름 전달
+                status: status ?? '', // 상태 전달
                 showSubTitle: true,
                 showExperienceButton: true, // 내 경험 보러가기 버튼 표시 여부
-                studentId: studentId!, // 학번 전달
+                studentId: studentId ?? '', // 학번 전달
               ),
               const SizedBox(height: 25),
               const Text(

--- a/frontend/lib/screens/myUserPage_screen.dart
+++ b/frontend/lib/screens/myUserPage_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:badges/badges.dart' as badges;
 import 'package:frontend/screens/favorite_screen.dart';
+import 'package:frontend/services/login_services.dart';
 import 'package:frontend/widgets/account_widget.dart';
 import 'package:frontend/widgets/profile_widget.dart';
 
@@ -12,8 +13,25 @@ class MyUserPage extends StatefulWidget {
 }
 
 class _MyUserPageState extends State<MyUserPage> {
-  bool isExpanded = false; // 내 팀 현황 확장성
+  bool isExpanded = false; // 내 팀 현황 확장성 여부를 나타내는 변수
+  String? studentId = ''; // 학번을 저장할 변수, 기본 값을 빈 문자열로 설정
 
+  @override
+  void initState() {
+    super.initState();
+    _loadStudentId(); // 학번을 로드하는 메서드 호출
+  }
+
+  // 학번을 로드하는 메서드
+  Future<void> _loadStudentId() async {
+    final loginAPI = LoginAPI(); // LoginAPI 인스턴스 생성
+    final credentials = await loginAPI.loadCredentials(); // 저장된 자격증명 로드
+    setState(() {
+      studentId = credentials['studentId'] ?? ''; // 학번 설정, 없으면 빈 문자열로 설정
+    });
+  }
+
+  // 개발 필드 리스트
   List<Map<String, dynamic>> fieldList = [
     {
       'logoUrl': 'assets/skilImages/typescript.png',
@@ -95,6 +113,7 @@ class _MyUserPageState extends State<MyUserPage> {
     },
   ];
 
+  // 개발 도구 리스트
   List<Map<String, dynamic>> toolsList = [
     {
       'logoUrl': 'assets/skilImages/github.png',
@@ -133,13 +152,13 @@ class _MyUserPageState extends State<MyUserPage> {
     return Scaffold(
       backgroundColor: Colors.white,
       appBar: AppBar(
-        scrolledUnderElevation: 0, // 스크롤 시 상단바 색상 바뀌는 오류
+        scrolledUnderElevation: 0, // 스크롤 시 상단바 색상 바뀌는 오류 방지
         toolbarHeight: 70,
         leading: Padding(
           padding: const EdgeInsets.only(left: 12.0),
           child: IconButton(
             onPressed: () {
-              Navigator.pushNamed(context, '/homepage');
+              Navigator.pushNamed(context, '/homepage'); // 홈 페이지로 이동
             },
             icon: Image.asset('assets/images/logo.png'),
             color: Colors.black,
@@ -160,7 +179,7 @@ class _MyUserPageState extends State<MyUserPage> {
               Navigator.push(
                 context,
                 MaterialPageRoute(
-                  builder: (context) => const FavoritePage(),
+                  builder: (context) => const FavoritePage(), // 즐겨찾기 페이지로 이동
                 ),
               );
             },
@@ -188,13 +207,13 @@ class _MyUserPageState extends State<MyUserPage> {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               // 프로필
-              const Profile(
+              Profile(
                 profileUrl: 'assets/images/profile.png',
                 name: '소진수',
                 showSubTitle: true,
-                showExperienceButton: true, // 내 경험 보러가기
+                showExperienceButton: true, // 내 경험 보러가기 버튼 표시 여부
+                studentId: studentId!, // 학번 전달
               ),
-
               const SizedBox(height: 25),
               const Text(
                 'DEVELOPMENT FIELD',
@@ -212,7 +231,6 @@ class _MyUserPageState extends State<MyUserPage> {
                 alignment: WrapAlignment.start,
                 spacing: 10,
                 runSpacing: 10,
-                // children 속성에 직접 전달하여 Iterable<Widget> 반환 문제 해결
                 children: fieldList.map((field) {
                   // 괄호 안에 있는 변수는 리스트를 map한 이름
                   return badge(
@@ -239,8 +257,6 @@ class _MyUserPageState extends State<MyUserPage> {
                 alignment: WrapAlignment.start,
                 spacing: 10,
                 runSpacing: 10,
-
-                // children 속성에 직접 전달하여 Iterable<Widget> 반환 문제 해결
                 children: toolsList.map((tools) {
                   return badge(
                     tools['logoUrl'],
@@ -338,6 +354,7 @@ class _MyUserPageState extends State<MyUserPage> {
     );
   }
 
+  // 배지 위젯 생성
   Widget badge(
     String logoUrl,
     String title,

--- a/frontend/lib/screens/settingProfile2_screen.dart
+++ b/frontend/lib/screens/settingProfile2_screen.dart
@@ -63,7 +63,8 @@ class _SettingProfile2PageState extends State<SettingProfile2Page> {
   Future<void> _onTapHandler() async {
     final projectName = projectNameController.text;
     final projectExperience = projectExperienceController.text;
-    final githubLink = githubLinkController.text;
+    final githubLink =
+        'https://github.com/${githubLinkController.text}'; // 깃허브 링크 저장 시 고정된 값 추가
     final roll = rollController.text;
     final part = partController.text;
 

--- a/frontend/lib/services/login_services.dart
+++ b/frontend/lib/services/login_services.dart
@@ -179,6 +179,7 @@ class LoginAPI {
           // 새 토큰 저장
           await prefs.setString('accessToken', accessToken); // 액세스 토큰 저장
           await prefs.setString('refreshToken', refreshToken); // 리프레시 토큰 저장
+          await prefs.setString('studentId', studentId); // 학번 저장
 
           final uri = Uri.parse(loginAddress);
           cookieJar.saveFromResponse(
@@ -187,8 +188,10 @@ class LoginAPI {
           // 저장된 토큰 로그로 확인
           final savedAccessToken = prefs.getString('accessToken');
           final savedRefreshToken = prefs.getString('refreshToken');
+          final savedStudentId = prefs.getString('studentId');
           print('저장된 액세스 토큰: $savedAccessToken');
           print('저장된 리프레시 토큰: $savedRefreshToken');
+          print('저장된 학번: $savedStudentId');
         }
         print('로그인 성공');
 

--- a/frontend/lib/services/login_services.dart
+++ b/frontend/lib/services/login_services.dart
@@ -38,10 +38,14 @@ class LoginAPI {
   Future<Map<String, dynamic>> loadCredentials() async {
     final prefs = await SharedPreferences.getInstance();
     final studentId = prefs.getString('studentId');
+    final name = prefs.getString('name'); // 이름 불러오기
+    final status = prefs.getString('status'); // 상태 불러오기
     final password = prefs.getString('password');
     final autoLogin = prefs.getBool('isAutoLogin') ?? false;
     return {
       'studentId': studentId,
+      'name': name, // 이름 추가
+      'status': status, // 상태 추가
       'password': password,
       'isAutoLogin': autoLogin,
     };
@@ -164,6 +168,8 @@ class LoginAPI {
         final userRole = responseData['userRole'];
         final techStack = responseData['techStack'];
         final memberExperience = responseData['memberExperiences'];
+        final name = responseData['name'];
+        final status = responseData['status'];
 
         final accessToken = response.headers['access']; // 액세스 토큰 추출
         final setCookieHeader = response.headers['set-cookie'];
@@ -180,6 +186,8 @@ class LoginAPI {
           await prefs.setString('accessToken', accessToken); // 액세스 토큰 저장
           await prefs.setString('refreshToken', refreshToken); // 리프레시 토큰 저장
           await prefs.setString('studentId', studentId); // 학번 저장
+          await prefs.setString('name', name); // 이름 저장
+          await prefs.setString('status', status); // 재적상태 저장
 
           final uri = Uri.parse(loginAddress);
           cookieJar.saveFromResponse(
@@ -189,9 +197,13 @@ class LoginAPI {
           final savedAccessToken = prefs.getString('accessToken');
           final savedRefreshToken = prefs.getString('refreshToken');
           final savedStudentId = prefs.getString('studentId');
+          final savedName = prefs.getString('name');
+          final savedStatus = prefs.getString('status');
           print('저장된 액세스 토큰: $savedAccessToken');
           print('저장된 리프레시 토큰: $savedRefreshToken');
           print('저장된 학번: $savedStudentId');
+          print('저장된 이름: $savedName');
+          print('저장된 상태: $savedStatus');
         }
         print('로그인 성공');
 

--- a/frontend/lib/services/projectExperience_service.dart
+++ b/frontend/lib/services/projectExperience_service.dart
@@ -70,4 +70,41 @@ class ProjectExperienceService {
       throw Exception('프로젝트 경험 여러 개 추가 실패: ${utf8.decode(response.bodyBytes)}');
     }
   }
+
+  // 내 프로젝트 경험 조회 API
+  Future<List<ProjectExperience>> fetchExperiences() async {
+    const String baseUrl =
+        'https://reminder.sungkyul.ac.kr/api/v1/member-experience';
+
+    final accessToken = await getToken();
+    if (accessToken == null) {
+      throw Exception('엑세스 토큰을 찾을 수 없음');
+    }
+
+    final url = Uri.parse(baseUrl);
+
+    final response = await http.get(
+      url,
+      headers: <String, String>{
+        'access': accessToken,
+      },
+    );
+
+    // 응답 데이터를 UTF-8로 디코딩하고 JSON 형식으로 변환
+    final responseData = jsonDecode(utf8.decode(response.bodyBytes));
+
+    if (response.statusCode == 200) {
+      // 응답 데이터에서 'data' 필드를 가져와서 리스트로 변환
+      List<ProjectExperience> fetchExperiences = (responseData['data'] as List)
+          .map((projectExperienceData) =>
+              ProjectExperience.fromJson(projectExperienceData))
+          .toList();
+
+      print("내 프로젝트 경험 조회 성공: $fetchExperiences");
+      return fetchExperiences;
+    } else {
+      print("내 프로젝트 경험 조회 실패");
+      return [];
+    }
+  }
 }

--- a/frontend/lib/widgets/profile_widget.dart
+++ b/frontend/lib/widgets/profile_widget.dart
@@ -1,10 +1,15 @@
 import 'package:flutter/material.dart';
+import 'package:frontend/models/projectExperience_model.dart';
+import 'package:frontend/providers/projectExperience_provider.dart';
+import 'package:frontend/screens/experience_screen.dart';
+import 'package:provider/provider.dart';
 
 class Profile extends StatelessWidget {
   final String profileUrl;
   final String name;
   final bool showSubTitle;
   final bool showExperienceButton;
+
   const Profile({
     required this.profileUrl,
     required this.name,
@@ -15,6 +20,9 @@ class Profile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final projectExperienceProvider =
+        Provider.of<ProjectExperienceProvider>(context, listen: false);
+
     return Card(
       color: const Color(0xFFFAFAFE),
       shape: RoundedRectangleBorder(
@@ -51,8 +59,20 @@ class Profile extends StatelessWidget {
                       const SizedBox(width: 5),
                       if (showExperienceButton)
                         GestureDetector(
-                          onTap: () {
-                            Navigator.pushNamed(context, '/experience');
+                          onTap: () async {
+                            // 프로젝트 경험 데이터를 가져옴
+                            await projectExperienceProvider.fetchExperiences();
+                            // 가져온 프로젝트 경험 데이터를 리스트로 저장
+                            List<ProjectExperience> experiences =
+                                projectExperienceProvider.projectExperiences;
+                            Navigator.push(
+                              context,
+                              MaterialPageRoute(
+                                builder: (context) => ExperiencePage(
+                                  experiences: experiences,
+                                ),
+                              ),
+                            );
                           },
                           child: Container(
                             height: 20,
@@ -79,7 +99,7 @@ class Profile extends StatelessWidget {
                   if (showSubTitle)
                     const Row(
                       children: [
-                        Text('20190906'),
+                        Text('20190906'), // 학번 또는 다른 정보를 표시
                         SizedBox(width: 5),
                         CircleAvatar(
                           radius: 2,

--- a/frontend/lib/widgets/profile_widget.dart
+++ b/frontend/lib/widgets/profile_widget.dart
@@ -7,6 +7,7 @@ import 'package:provider/provider.dart';
 class Profile extends StatelessWidget {
   final String profileUrl;
   final String name;
+  final String status;
   final bool showSubTitle;
   final bool showExperienceButton;
   final String studentId;
@@ -14,6 +15,7 @@ class Profile extends StatelessWidget {
   const Profile({
     required this.profileUrl,
     required this.name,
+    required this.status,
     required this.showSubTitle,
     required this.studentId,
     this.showExperienceButton = false,
@@ -72,6 +74,7 @@ class Profile extends StatelessWidget {
                               MaterialPageRoute(
                                 builder: (context) => ExperiencePage(
                                   experiences: experiences,
+                                  name: name,
                                 ),
                               ),
                             );
@@ -101,14 +104,14 @@ class Profile extends StatelessWidget {
                   if (showSubTitle)
                     Row(
                       children: [
-                        Text(studentId), // 학번 또는 다른 정보를 표시
+                        Text(studentId), // 학번 표시
                         const SizedBox(width: 5),
                         const CircleAvatar(
                           radius: 2,
                           backgroundColor: Color(0xFF808080),
                         ),
                         const SizedBox(width: 5),
-                        const Text('재학생'),
+                        Text(status), // 상태 표시
                       ],
                     ),
                 ],

--- a/frontend/lib/widgets/profile_widget.dart
+++ b/frontend/lib/widgets/profile_widget.dart
@@ -9,11 +9,13 @@ class Profile extends StatelessWidget {
   final String name;
   final bool showSubTitle;
   final bool showExperienceButton;
+  final String studentId;
 
   const Profile({
     required this.profileUrl,
     required this.name,
     required this.showSubTitle,
+    required this.studentId,
     this.showExperienceButton = false,
     super.key,
   });
@@ -97,16 +99,16 @@ class Profile extends StatelessWidget {
                     ],
                   ),
                   if (showSubTitle)
-                    const Row(
+                    Row(
                       children: [
-                        Text('20190906'), // 학번 또는 다른 정보를 표시
-                        SizedBox(width: 5),
-                        CircleAvatar(
+                        Text(studentId), // 학번 또는 다른 정보를 표시
+                        const SizedBox(width: 5),
+                        const CircleAvatar(
                           radius: 2,
                           backgroundColor: Color(0xFF808080),
                         ),
-                        SizedBox(width: 5),
-                        Text('재학생'),
+                        const SizedBox(width: 5),
+                        const Text('재학생'),
                       ],
                     ),
                 ],

--- a/frontend/lib/widgets/profile_widget.dart
+++ b/frontend/lib/widgets/profile_widget.dart
@@ -4,11 +4,14 @@ class Profile extends StatelessWidget {
   final String profileUrl;
   final String name;
   final bool showSubTitle;
-  const Profile(
-      {required this.profileUrl,
-      required this.name,
-      required this.showSubTitle,
-      super.key});
+  final bool showExperienceButton;
+  const Profile({
+    required this.profileUrl,
+    required this.name,
+    required this.showSubTitle,
+    this.showExperienceButton = false,
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -20,31 +23,76 @@ class Profile extends StatelessWidget {
       elevation: 0.5,
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 20.0, vertical: 26.0),
-        child: ListTile(
-          leading: ClipRRect(
-            child: Image.asset(profileUrl),
-          ),
-          title: Text(
-            name,
-            style: const TextStyle(
-              fontSize: 18,
-              fontWeight: FontWeight.bold,
+        child: Row(
+          children: [
+            ClipRRect(
+              borderRadius: BorderRadius.circular(50.0), // 프로필 이미지 둥글게
+              child: Image.asset(
+                profileUrl,
+                width: 50,
+                height: 50,
+                fit: BoxFit.cover,
+              ),
             ),
-          ),
-          subtitle: showSubTitle
-              ? const Row(
-                  children: [
-                    Text('20190906'),
-                    SizedBox(width: 5),
-                    CircleAvatar(
-                      radius: 2,
-                      backgroundColor: Color(0xFF808080),
+            const SizedBox(width: 20),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    children: [
+                      Text(
+                        name,
+                        style: const TextStyle(
+                          fontSize: 18,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      const SizedBox(width: 5),
+                      if (showExperienceButton)
+                        GestureDetector(
+                          onTap: () {
+                            Navigator.pushNamed(context, '/experience');
+                          },
+                          child: Container(
+                            height: 20,
+                            width: 100,
+                            margin: const EdgeInsets.only(left: 10),
+                            decoration: BoxDecoration(
+                              color: const Color(0xFF2A72E7),
+                              borderRadius: BorderRadius.circular(6),
+                            ),
+                            child: const Center(
+                              child: Text(
+                                '내 경험 보러가기',
+                                style: TextStyle(
+                                  fontSize: 10,
+                                  fontWeight: FontWeight.bold,
+                                  color: Colors.white,
+                                ),
+                              ),
+                            ),
+                          ),
+                        ),
+                    ],
+                  ),
+                  if (showSubTitle)
+                    const Row(
+                      children: [
+                        Text('20190906'),
+                        SizedBox(width: 5),
+                        CircleAvatar(
+                          radius: 2,
+                          backgroundColor: Color(0xFF808080),
+                        ),
+                        SizedBox(width: 5),
+                        Text('재학생'),
+                      ],
                     ),
-                    SizedBox(width: 5),
-                    Text('재학생'),
-                  ],
-                )
-              : null,
+                ],
+              ),
+            ),
+          ],
         ),
       ),
     );


### PR DESCRIPTION
## 📌 관련 이슈
#99 

## ✨ 코드 변경 내용
[로그인 후 MyUserPage 프로필 이름과 재적상태 일치되도록 구현]

[LoginAPI_Service]
- 로그인할 때 name, status SharedPreferences에 저장하는 코드 추가 구현
- 저장된 name, status를 loadCredentials 메서드로 가져오기 위해 getString 방식 적용

[MyUserPage]
- 이름, 재적상태를 로드하는 메서드 _loadStudentId 선언하여 이름과 재적상태 관리
- 이름과 재적상태가 없는 경우 기본 값을 빈 문자열로 설정

[Profile]
- name, status 매개변수 추가
- showSubTitle이 true인 경우 status를 화면에 표시되도록 구현

[ExperiencePage]
- 로그인 후 해당 학생 이름으로 상태 변경되도록 구현

[main]
ExperiencePage에 파라미터로 name 추가

## 📸 스크린샷(선택)
https://github.com/user-attachments/assets/da16cef6-1bb4-4178-a3c8-3e76753f20db


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
