### PR TITLE
[feat : #100] 프로젝트 경험 수정 API 연동

### DIFF
--- a/frontend/lib/models/projectExperience_model.dart
+++ b/frontend/lib/models/projectExperience_model.dart
@@ -1,4 +1,6 @@
 class ProjectExperience {
+  int? id; // 선택적 필드
+  int? memberId; // 선택적 필드
   String experienceName;
   String experienceRole;
   String experienceContent;
@@ -7,6 +9,8 @@ class ProjectExperience {
   String experienceDate;
 
   ProjectExperience({
+    this.id,
+    this.memberId,
     required this.experienceName,
     required this.experienceRole,
     required this.experienceContent,
@@ -16,18 +20,24 @@ class ProjectExperience {
   });
 
   factory ProjectExperience.fromJson(Map<String, dynamic> json) {
+    // JSON 데이터에서 id와 memberId를 추출
+    final id = json['id'] as int?;
+    final memberId = json['memberId'] as int?;
+
     return ProjectExperience(
-      experienceName: json['experienceName'],
-      experienceRole: json['experienceRole'],
-      experienceContent: json['experienceContent'],
-      experienceGithub: json['experienceGithub'],
-      experienceJob: json['experienceJob'],
-      experienceDate: json['experienceDate'],
+      id: id,
+      memberId: memberId,
+      experienceName: json['experienceName'] as String,
+      experienceRole: json['experienceRole'] as String,
+      experienceContent: json['experienceContent'] as String,
+      experienceGithub: json['experienceGithub'] as String,
+      experienceJob: json['experienceJob'] as String,
+      experienceDate: json['experienceDate'] as String,
     );
   }
 
   Map<String, dynamic> toJson() {
-    return {
+    final Map<String, dynamic> data = {
       'experienceName': experienceName,
       'experienceRole': experienceRole,
       'experienceContent': experienceContent,
@@ -35,10 +45,17 @@ class ProjectExperience {
       'experienceJob': experienceJob,
       'experienceDate': experienceDate,
     };
+
+    // id 필드를 백엔드로 보내지 않도록 함
+    if (memberId != null) {
+      data['memberId'] = memberId;
+    }
+
+    return data;
   }
 
   @override
   String toString() {
-    return 'experienceName: $experienceName, experienceRole: $experienceRole, experienceContent: $experienceContent, experienceGithub: $experienceGithub, experienceJob: $experienceJob, experienceDate: $experienceDate ';
+    return 'id: $id, memberId: $memberId, experienceName: $experienceName, experienceRole: $experienceRole, experienceContent: $experienceContent, experienceGithub: $experienceGithub, experienceJob: $experienceJob, experienceDate: $experienceDate';
   }
 }

--- a/frontend/lib/providers/projectExperience_provider.dart
+++ b/frontend/lib/providers/projectExperience_provider.dart
@@ -6,7 +6,7 @@ class ProjectExperienceProvider with ChangeNotifier {
   final ProjectExperienceService service = ProjectExperienceService();
 
   List<ProjectExperience> projectExperiences =
-      []; // Datatable에 표시할 프로젝트 경험 정보 리스트
+      []; // DataTable에 표시할 프로젝트 경험 정보 리스트
 
   // 프로젝트 경험 정보를 담는 메소드를 호출(그래야만 프로젝트 경험 정보를 projectExperiences에 담고 반환할 수 있음)
   // projectExperiences 반환
@@ -29,7 +29,7 @@ class ProjectExperienceProvider with ChangeNotifier {
     }
   }
 
-  // 프로젝트 경험 여러개 추가
+  // 프로젝트 경험 여러 개 추가
   Future<void> createProjectExperiences(
       List<ProjectExperience> projectExperienceList) async {
     try {
@@ -51,10 +51,34 @@ class ProjectExperienceProvider with ChangeNotifier {
       List<ProjectExperience> fetchExperiences =
           await service.fetchExperiences();
 
-      // fetchExperiences 매서드로 가져온 프로젝트 경험 정보를 projectExperiences 리스트에 할당
+      // fetchExperiences 메서드로 가져온 프로젝트 경험 정보를 projectExperiences 리스트에 할당
       projectExperiences = fetchExperiences;
 
       notifyListeners(); // 상태 변경을 알림
+    } catch (e) {
+      print(e);
+    }
+  }
+
+  // 프로젝트 경험 수정
+  Future<void> updateProjectExperience(
+      ProjectExperience updatedProjectExperience) async {
+    try {
+      // 프로젝트 경험 리스트에서 수정된 항목을 찾아서 업데이트
+      int index = projectExperiences
+          .indexWhere((exp) => exp.id == updatedProjectExperience.id);
+
+      if (index != -1) {
+        // 프로젝트 경험 수정 API를 호출
+        await service.updateProjectExperience(updatedProjectExperience);
+
+        // 수정된 항목을 바로 리스트에 반영
+        projectExperiences[index] = updatedProjectExperience;
+        notifyListeners(); // 상태 변경 알림
+        print('index: $index');
+      } else {
+        print('수정할 프로젝트 경험을 찾을 수 없습니다.');
+      }
     } catch (e) {
       print(e);
     }

--- a/frontend/lib/screens/experience_screen.dart
+++ b/frontend/lib/screens/experience_screen.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:frontend/models/projectExperience_model.dart';
+import 'package:frontend/providers/projectExperience_provider.dart';
+import 'package:provider/provider.dart';
 
 class ExperiencePage extends StatefulWidget {
   final List<ProjectExperience> experiences;
@@ -73,88 +75,98 @@ class ExperiencePageState extends State<ExperiencePage> {
                 const Spacer(),
                 Visibility(
                   visible: _isExpanded.contains(true),
-                  child: GestureDetector(
-                    onTap: () {},
-                    child: Container(
-                      height: 20,
-                      width: 100,
-                      margin: const EdgeInsets.only(left: 10),
-                      decoration: BoxDecoration(
-                        color: const Color(0xFF2A72E7),
-                        borderRadius: BorderRadius.circular(6),
-                      ),
-                      child: const Center(
-                        child: Text(
-                          '경험 수정하기',
-                          style: TextStyle(
-                            fontSize: 10,
-                            fontWeight: FontWeight.bold,
-                            color: Colors.white,
+                  child: Row(
+                    children: [
+                      GestureDetector(
+                        onTap: () {
+                          _editSelectedExperience();
+                        },
+                        child: Container(
+                          height: 20,
+                          width: 100,
+                          margin: const EdgeInsets.only(left: 10),
+                          decoration: BoxDecoration(
+                            color: const Color(0xFF2A72E7),
+                            borderRadius: BorderRadius.circular(6),
+                          ),
+                          child: const Center(
+                            child: Text(
+                              '경험 수정하기',
+                              style: TextStyle(
+                                fontSize: 10,
+                                fontWeight: FontWeight.bold,
+                                color: Colors.white,
+                              ),
+                            ),
                           ),
                         ),
                       ),
-                    ),
+                    ],
                   ),
                 ),
               ],
             ),
             const SizedBox(height: 20),
             Expanded(
-              child: ListView.builder(
-                itemCount: widget.experiences.length,
-                itemBuilder: (context, index) {
-                  final experience = widget.experiences[index];
-                  return Column(
-                    children: [
-                      ExpansionTile(
-                        title: userInfo(
-                          title: '프로젝트명',
-                          titleSize: 20,
-                          info: experience.experienceName,
-                        ),
-                        onExpansionChanged: (bool expanded) {
-                          setState(() {
-                            _isExpanded[index] = expanded;
-                          });
-                        },
+              child: Consumer<ProjectExperienceProvider>(
+                builder: (context, provider, child) {
+                  return ListView.builder(
+                    itemCount: provider.projectExperiences.length,
+                    itemBuilder: (context, index) {
+                      final experience = provider.projectExperiences[index];
+                      return Column(
                         children: [
-                          Padding(
-                            padding:
-                                const EdgeInsets.symmetric(horizontal: 20.0),
-                            child: Column(
-                              children: [
-                                userInfo(
-                                  title: '나의 역할',
-                                  titleSize: 18,
-                                  info: experience.experienceRole,
-                                ),
-                                userInfo(
-                                  title: '프로젝트 경험',
-                                  titleSize: 18,
-                                  info: experience.experienceContent,
-                                ),
-                                userInfo(
-                                  title: '깃허브 프로젝트 링크',
-                                  titleSize: 18,
-                                  info: experience.experienceGithub,
-                                ),
-                                userInfo(
-                                  title: '직무',
-                                  titleSize: 18,
-                                  info: experience.experienceJob,
-                                ),
-                                userInfo(
-                                  title: '프로젝트 기간',
-                                  titleSize: 18,
-                                  info: experience.experienceDate,
-                                ),
-                              ],
+                          ExpansionTile(
+                            title: userInfo(
+                              title: '프로젝트명',
+                              titleSize: 20,
+                              info: experience.experienceName,
                             ),
+                            onExpansionChanged: (bool expanded) {
+                              setState(() {
+                                _isExpanded[index] = expanded;
+                              });
+                            },
+                            children: [
+                              Padding(
+                                padding: const EdgeInsets.symmetric(
+                                    horizontal: 20.0),
+                                child: Column(
+                                  children: [
+                                    userInfo(
+                                      title: '나의 역할',
+                                      titleSize: 18,
+                                      info: experience.experienceRole,
+                                    ),
+                                    userInfo(
+                                      title: '프로젝트 경험',
+                                      titleSize: 18,
+                                      info: experience.experienceContent,
+                                    ),
+                                    userInfo(
+                                      title: '깃허브 프로젝트 링크',
+                                      titleSize: 18,
+                                      info: experience.experienceGithub,
+                                    ),
+                                    userInfo(
+                                      title: '직무',
+                                      titleSize: 18,
+                                      info: experience.experienceJob,
+                                    ),
+                                    userInfo(
+                                      title: '프로젝트 기간',
+                                      titleSize: 18,
+                                      info: experience.experienceDate,
+                                    ),
+                                  ],
+                                ),
+                              ),
+                            ],
                           ),
+                          const SizedBox(height: 10),
                         ],
-                      ),
-                      const SizedBox(height: 10),
-                    ],
+                      );
+                    },
                   );
                 },
               ),
@@ -195,6 +207,107 @@ class ExperiencePageState extends State<ExperiencePage> {
           ),
         ),
       ],
+    );
+  }
+
+  // 선택한 경험 수정하는 메서드
+  void _editSelectedExperience() {
+    // _isExpanded 리스트에서 확장된 타일의 인덱스 찾음
+    final selectedIndex = _isExpanded.indexWhere((expanded) => expanded);
+    // 확장된 타일이 있는 경우
+    if (selectedIndex != -1) {
+      // 해당 인덱스의 경험 데이터를 가져옴
+      final experience = context
+          .read<ProjectExperienceProvider>()
+          .projectExperiences[selectedIndex];
+      // 경험 수정 다이얼로그를 표시
+      _showEditExperienceDialog(context, experience, selectedIndex);
+    }
+  }
+
+  // 경험 수정 다이얼로그
+  void _showEditExperienceDialog(
+      BuildContext context, ProjectExperience experience, int index) {
+    // 각 필드를 위한 TextEditingController를 생성하고, 초기값을 설정
+    final TextEditingController nameController =
+        TextEditingController(text: experience.experienceName);
+    final TextEditingController roleController =
+        TextEditingController(text: experience.experienceRole);
+    final TextEditingController contentController =
+        TextEditingController(text: experience.experienceContent);
+    final TextEditingController githubController =
+        TextEditingController(text: experience.experienceGithub);
+    final TextEditingController jobController =
+        TextEditingController(text: experience.experienceJob);
+    final TextEditingController dateController =
+        TextEditingController(text: experience.experienceDate);
+
+    // 다이얼로그를 생성하고 표시
+    showDialog(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: const Text('경험 수정하기'),
+          content: SingleChildScrollView(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                // 각각의 TextField를 생성하고 해당 컨트롤러와 라벨을 설정
+                _buildTextField(nameController, '프로젝트명'),
+                _buildTextField(roleController, '나의 역할'),
+                _buildTextField(contentController, '프로젝트 경험'),
+                _buildTextField(githubController, '깃허브 프로젝트 링크'),
+                _buildTextField(jobController, '직무'),
+                _buildTextField(dateController, '프로젝트 기간'),
+              ],
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () {
+                Navigator.of(context).pop();
+              },
+              child: const Text('취소'),
+            ),
+            TextButton(
+              onPressed: () {
+                // 업데이트된 경험 데이터를 생성
+                final updatedExperience = ProjectExperience(
+                  id: experience.id, // 기존 ID 유지
+                  experienceName: nameController.text,
+                  experienceRole: roleController.text,
+                  experienceContent: contentController.text,
+                  experienceGithub: githubController.text,
+                  experienceJob: jobController.text,
+                  experienceDate: dateController.text,
+                );
+
+                // Provider를 사용하여 경험 데이터를 업데이트하고, UI를 갱신
+                Provider.of<ProjectExperienceProvider>(context, listen: false)
+                    .updateProjectExperience(updatedExperience)
+                    .then((_) {
+                  Navigator.of(context).pop();
+                });
+              },
+              child: const Text('저장'),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  // 텍스트 필드를 생성하는 헬퍼 함수
+  Widget _buildTextField(TextEditingController controller, String label) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8.0),
+      child: TextField(
+        controller: controller,
+        decoration: InputDecoration(
+          labelText: label,
+          border: const OutlineInputBorder(),
+        ),
+      ),
     );
   }
 }

--- a/frontend/lib/screens/myOwnerPage_screen.dart
+++ b/frontend/lib/screens/myOwnerPage_screen.dart
@@ -98,7 +98,9 @@ class _MyOwnerPageState extends State<MyOwnerPage> {
             const Profile(
               profileUrl: 'assets/images/profile.png',
               name: '홍길동',
+              status: 'Admin',
               showSubTitle: false,
+              studentId: '2090',
             ),
             const SizedBox(height: 25),
 

--- a/frontend/lib/screens/recruitDetail_screen.dart
+++ b/frontend/lib/screens/recruitDetail_screen.dart
@@ -306,7 +306,10 @@ class _RecruitDetailPageState extends State<RecruitDetailPage> {
                     Navigator.push(
                       context,
                       MaterialPageRoute(
-                        builder: (context) => const ExperiencePage(),
+                        builder: (context) => const ExperiencePage(
+                          experiences: [],
+                          name: '',
+                        ),
                       ),
                     );
                   },

--- a/frontend/lib/services/login_services.dart
+++ b/frontend/lib/services/login_services.dart
@@ -204,6 +204,13 @@ class LoginAPI {
           print('저장된 학번: $savedStudentId');
           print('저장된 이름: $savedName');
           print('저장된 상태: $savedStatus');
+
+          // memberExperience 배열에서 id 값 추출하여 저장
+          final memberExperienceIds = (memberExperience as List)
+              .map((exp) => (exp['id'] as int).toString()) // int를 String으로 변환
+              .toList();
+          await prefs.setStringList('memberExperienceIds', memberExperienceIds);
+          print('저장된 memberExperience id: $memberExperienceIds');
         }
         print('로그인 성공');
 


### PR DESCRIPTION
## 📌 관련 이슈
#100 

## ✨ 코드 변경 내용
[Login_Service]
-  memberExperience 배열에서 id 값 추출하여 저장

[ProjectExperienceService]
- memberExperience 배열에서 추출한 id 값 가져옴
- 가져온 id 값을 experienceIds 변수의 저장
- projectExperience 객체에서 id를 추출

[Model]
- id 필드와 memberId 필드 추가 적용
- JSON 데이터에서 id와 memberId 추출

[Provider]
- projectExperiences 리스트에서 updatedProjectExperience와 동일한 id를 가진 항목의 인덱스를 찾도록 변경

[RecruitDetailPage]
- ExperiencePage 이동 시 필요한 파라미터 추가

[ExperiencePage]
- Provider를 사용하여 경험 데이터를 업데이트 및 즉시 반영되도록 구현

[MyOwnerPage]
- Profile 누락된 정보 추가

## 📸 스크린샷(선택)
<img width="711" alt="KakaoTalk_Photo_2024-07-23-16-02-10" src="https://github.com/user-attachments/assets/96555273-7ca4-424d-b866-87aaaeccb3ae">



## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
