### PR TITLE
[Feat/#112] 게시글 전체 조회 API 연동

### DIFF
--- a/frontend/lib/all/providers/announcement_provider.dart
+++ b/frontend/lib/all/providers/announcement_provider.dart
@@ -1,0 +1,123 @@
+import 'dart:convert';
+import 'dart:io';
+import 'package:flutter/material.dart';
+import 'package:frontend/all/providers/models/board_model.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:http/http.dart' as http;
+import 'package:path/path.dart' as path;
+
+class AnnouncementProvider with ChangeNotifier {
+  late Board _board;
+  final List<Map<String, dynamic>> _boardList = [];
+
+  Board get board => _board;
+  List<Map<String, dynamic>> get boardList => _boardList;
+
+  // 엑세스 토큰 할당
+  Future<String?> getToken() async {
+    SharedPreferences prefs = await SharedPreferences.getInstance();
+    return prefs.getString('accessToken'); // accessToken 키로 저장된 문자열 값을 가져옴
+  }
+
+  final String baseUrl = 'http://10.0.2.2:9000/api/v1/announcement';
+
+  Future<int> createBoard(
+      Board board, List<File> pickedImages, List<File> pickedFiles) async {
+    final accessToken = await getToken();
+    if (accessToken == null) {
+      throw Exception('엑세스 토큰을 찾을 수 없음');
+    }
+    final url = Uri.parse(baseUrl);
+    final boardInfo = http.MultipartRequest('POST', url);
+    // 엑세스 토큰 추가
+    boardInfo.headers['access'] = accessToken;
+    // 텍스트 데이터 추가
+    boardInfo.fields['announcementCategory'] = board.announcementCategory!;
+    boardInfo.fields['announcementTitle'] = board.announcementTitle!;
+    boardInfo.fields['announcementContent'] = board.announcementContent!;
+    boardInfo.fields['announcementImportant'] =
+        board.announcementImportant.toString();
+    boardInfo.fields['visible'] = board.visible.toString();
+    boardInfo.fields['announcementLevel'] = board.announcementLevel.toString();
+    // 이미지 파일 추가
+    if (pickedImages.isNotEmpty) {
+      for (var img in pickedImages) {
+        var multipartFile = await http.MultipartFile.fromPath(
+          'img',
+          img.path,
+          filename: path.basename(img.path),
+        );
+        boardInfo.files.add(multipartFile);
+      }
+    }
+    // 일반 파일 추가
+    if (pickedFiles.isNotEmpty) {
+      print('pickedFiles: $pickedFiles');
+      for (var file in pickedFiles) {
+        var bytes = await file.readAsBytes();
+        var multipartFile = http.MultipartFile.fromBytes(
+          'file',
+          bytes,
+          filename: path.basename(file.path),
+        );
+        boardInfo.files.add(multipartFile);
+      }
+    }
+    try {
+      final response = await boardInfo.send();
+      final responseString = await response.stream.bytesToString();
+      if (response.statusCode == 201) {
+        final Map<String, dynamic> responseBody = jsonDecode(responseString);
+        print('작성 성공: $responseBody');
+
+        _board = Board.fromJson(responseBody['data']);
+        print(_board);
+        notifyListeners();
+
+        return _board.id!;
+      } else {
+        print('작성 실패: ${response.statusCode} - $responseString');
+        throw Exception();
+      }
+    } catch (e) {
+      print('Exception: $e');
+      throw Exception();
+    }
+  }
+
+  Future<void> fetchAllBoards() async {
+    try {
+      final accessToken = await getToken();
+      if (accessToken == null) {
+        throw Exception('엑세스 토큰을 찾을 수 없음');
+      }
+
+      final url = Uri.parse(baseUrl);
+      final response = await http.get(
+        url,
+        headers: {
+          'access': accessToken,
+        },
+      );
+
+      final utf8Response = utf8.decode(response.bodyBytes);
+      final jsonResponse = json.decode(utf8Response)
+          as Map<String, dynamic>; // JSON 문자열을 Map 객체로 변환
+
+      final dataResponse = jsonResponse['data']; // 'data' 키에 접근
+
+      if (response.statusCode == 200) {
+        // 각 항목이 Map<String, dynamic>이라고 가정하고 추가
+        for (var data in dataResponse) {
+          _boardList.add(data);
+          notifyListeners();
+        }
+        print('조회 성공: $_boardList');
+      } else {
+        print('조회 실패: ${response.bodyBytes}');
+      }
+    } catch (e) {
+      print(e.toString());
+    }
+  }
+}

--- a/frontend/lib/all/providers/models/board_model.dart
+++ b/frontend/lib/all/providers/models/board_model.dart
@@ -1,0 +1,48 @@
+class Board {
+  int? id;
+  String? announcementCategory;
+  String? announcementTitle;
+  String? announcementContent;
+  bool? announcementImportant;
+  bool? visible;
+  int? announcementLevel;
+
+  Board({
+    this.id,
+    required this.announcementCategory,
+    required this.announcementTitle,
+    required this.announcementContent,
+    required this.announcementImportant,
+    required this.visible,
+    required this.announcementLevel,
+  });
+
+  factory Board.fromJson(Map<String, dynamic> json) {
+    return Board(
+      id: json['id'],
+      announcementCategory: json['announcementCategory'],
+      announcementTitle: json['announcementTitle'],
+      announcementContent: json['announcementContent'],
+      announcementImportant: json['announcementImportant'],
+      visible: json['visible'],
+      announcementLevel: json['announcementLevel'],
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'announcementCategory': announcementCategory,
+      'announcementTitle': announcementTitle,
+      'announcementContent': announcementContent,
+      'announcementImportant': announcementImportant,
+      'visible': visible,
+      'announcementLevel': announcementLevel,
+    };
+  }
+
+  @override
+  String toString() {
+    return 'id: $id, announcementCategory: $announcementCategory, announcementTitle: $announcementTitle, announcementContent: $announcementContent, announcementImportant: $announcementImportant, visible: $visible, announcementLevel: $announcementLevel';
+  }
+}

--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:frontend/all/providers/announcement_provider.dart';
 import 'package:frontend/screens/editField_screen.dart';
 import 'package:frontend/screens/editTool_screen.dart';
 import 'package:get/get.dart';
@@ -96,6 +97,7 @@ void main() async {
         ChangeNotifierProvider(create: (_) => ProjectExperienceProvider()),
         ChangeNotifierProvider(create: (_) => ProfileProvider()),
         ChangeNotifierProvider(create: (_) => MakeTeamProvider()),
+        ChangeNotifierProvider(create: (_) => AnnouncementProvider()),
       ],
       child: const MyApp(),
     ),

--- a/frontend/lib/screens/board_screen.dart
+++ b/frontend/lib/screens/board_screen.dart
@@ -1,12 +1,14 @@
 import 'package:flutter/material.dart';
+import 'package:frontend/all/providers/announcement_provider.dart';
 import 'package:frontend/screens/hiddenList_screen.dart';
 import 'package:frontend/screens/home_screen.dart';
 import 'package:frontend/screens/write_screen.dart';
+import 'package:frontend/widgets/boardAppbar_widget.dart';
 import 'package:frontend/widgets/board_widget.dart';
 import 'package:frontend/widgets/levelBtn_widget.dart';
 
 class BoardPage extends StatefulWidget {
-  const BoardPage({Key? key}) : super(key: key);
+  const BoardPage({super.key});
 
   @override
   State<BoardPage> createState() => _BoardPageState();
@@ -163,46 +165,14 @@ class _BoardPageState extends State<BoardPage> {
   }
 
   @override
+  void initState() {
+    super.initState();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        toolbarHeight: 70,
-        leadingWidth: 140,
-        leading: Padding(
-          padding: const EdgeInsets.only(left: 12.0),
-          child: IconButton(
-            onPressed: () {},
-            icon: Image.asset('assets/images/logo.png'),
-            color: Colors.black,
-          ),
-        ),
-        actions: const [
-          Padding(
-            padding: EdgeInsets.only(right: 23.0),
-            child: Icon(
-              Icons.search,
-              size: 30,
-              color: Colors.black,
-            ),
-          ),
-          Padding(
-            padding: EdgeInsets.only(right: 23.0),
-            child: Icon(
-              Icons.add_alert,
-              size: 30,
-              color: Colors.black,
-            ),
-          ),
-          Padding(
-            padding: EdgeInsets.only(right: 23.0),
-            child: Icon(
-              Icons.account_circle,
-              size: 30,
-              color: Colors.black,
-            ),
-          ),
-        ],
-      ),
+      appBar: const BoardAppbar(),
       body: Padding(
         padding: const EdgeInsets.symmetric(
           horizontal: 20,
@@ -216,7 +186,7 @@ class _BoardPageState extends State<BoardPage> {
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
                 const Text(
-                  '학년 공지',
+                  '전체 공지',
                   style: TextStyle(
                     fontSize: 20,
                     fontWeight: FontWeight.bold,
@@ -271,6 +241,7 @@ class _BoardPageState extends State<BoardPage> {
                       selectedGrade == '1학년', // 전달 받은 학년과 버튼 학년과 동일하면 true 반환
                   // 전달 받은 grade 값을 selectedGrade에 저장
                   onSelectedGrade: (grade) {
+                    // 일관되게 grade로 통일
                     setState(() {
                       // 다른 학년 버튼 시 숨김/삭제 버튼 비활성화
                       // 이 콜백 함수가 onPressed 함수 내에 있어서 여기에 코드 작성
@@ -305,58 +276,60 @@ class _BoardPageState extends State<BoardPage> {
                 GradeBtn(
                   grade: '4학년',
                   isSelected: selectedGrade == '4학년',
-                  onSelectedGrade: (level) {
+                  onSelectedGrade: (grade) {
+                    // 일관되게 grade로 통일
                     setState(() {
                       isHidDel = false;
-                      selectedGrade = level;
+                      selectedGrade = grade;
                     });
                   },
                 ),
               ],
             ),
+
             const SizedBox(height: 13),
             // 해당 학년 공지 표시
-            if (selectedGrade == '1학년')
-              // 전달받은 isEdited 값을 isHidDel 값에 저장
-              Board(
-                boardList: oneBoard,
-                onChecked: (isPressed) {
-                  setState(() {
-                    isHidDel = isPressed;
-                  });
-                },
-                isShowed: isHidDel,
-              )
-            else if (selectedGrade == '2학년')
-              Board(
-                boardList: twoBoard,
-                onChecked: (isPressed) {
-                  setState(() {
-                    isHidDel = isPressed;
-                  });
-                },
-                isShowed: isHidDel,
-              )
-            else if (selectedGrade == '3학년')
-              Board(
-                boardList: threeBoard,
-                onChecked: (isPressed) {
-                  setState(() {
-                    isHidDel = isPressed;
-                  });
-                },
-                isShowed: isHidDel,
-              )
-            else if (selectedGrade == '4학년')
-              Board(
-                boardList: fourBoard,
-                onChecked: (isPressed) {
-                  setState(() {
-                    isHidDel = isPressed;
-                  });
-                },
-                isShowed: isHidDel,
-              )
+            // if (selectedGrade == '1학년')
+            //   // 전달받은 isEdited 값을 isHidDel 값에 저장
+            //   Board(
+            //     boardList: oneBoard,
+            //     onChecked: (isPressed) {
+            //       setState(() {
+            //         isHidDel = isPressed;
+            //       });
+            //     },
+            //     isShowed: isHidDel,
+            //   )
+            // else if (selectedGrade == '2학년')
+            //   Board(
+            //     boardList: twoBoard,
+            //     onChecked: (isPressed) {
+            //       setState(() {
+            //         isHidDel = isPressed;
+            //       });
+            //     },
+            //     isShowed: isHidDel,
+            //   )
+            // else if (selectedGrade == '3학년')
+            //   Board(
+            //     boardList: threeBoard,
+            //     onChecked: (isPressed) {
+            //       setState(() {
+            //         isHidDel = isPressed;
+            //       });
+            //     },
+            //     isShowed: isHidDel,
+            //   )
+            // else if (selectedGrade == '4학년')
+            //   Board(
+            //     boardList: fourBoard,
+            //     onChecked: (isPressed) {
+            //       setState(() {
+            //         isHidDel = isPressed;
+            //       });
+            //     },
+            //     isShowed: isHidDel,
+            //   )
           ],
         ),
       ),

--- a/frontend/lib/screens/home_screen.dart
+++ b/frontend/lib/screens/home_screen.dart
@@ -2,12 +2,10 @@ import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:frontend/providers/profile_provider.dart';
-import 'package:frontend/screens/myUserPage_screen.dart';
+import 'package:frontend/screens/totalBoard_screen.dart';
 import 'package:provider/provider.dart';
-import 'package:frontend/screens/myOwnerPage_screen.dart';
 import 'package:frontend/services/notification_services.dart';
 import 'package:frontend/screens/makeTeam_screen.dart';
-import 'package:frontend/screens/myUserPage_screen.dart';
 import 'package:table_calendar/table_calendar.dart';
 
 class HomePage extends StatefulWidget {
@@ -409,8 +407,19 @@ class _HomePageState extends State<HomePage> {
                     crossAxisSpacing: 9.0, // 같은 행의 iteme들 사이의 간
 
                     children: [
-                      homeItem(
-                          imgPath: 'assets/images/general.png', title: '전체공지'),
+                      GestureDetector(
+                        onTap: () {
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder: (context) => const TotalBoardPage(),
+                            ),
+                          );
+                        },
+                        child: homeItem(
+                            imgPath: 'assets/images/general.png',
+                            title: '전체공지'),
+                      ),
                       homeItem(
                           imgPath: 'assets/images/grade.png', title: '학년공지'),
                       homeItem(

--- a/frontend/lib/screens/login_screen.dart
+++ b/frontend/lib/screens/login_screen.dart
@@ -173,6 +173,7 @@ class _LoginPageState extends State<LoginPage> {
 
     return token!;
   }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -336,11 +337,15 @@ class _LoginPageState extends State<LoginPage> {
               ElevatedButton(
                 onPressed: () async {
                   await _getFCMToken();
+
                   // 유효성 통과 시 홈 화면으로 이동
                   if (formKey.currentState!.validate()) {
                     String studentId = idController.text;
                     String password = pwController.text;
                     String fcmToken = await _getFCMToken(); // 토큰 발급
+
+                    print('fcmToken: $fcmToken');
+
                     LoginAPI()
                         .handleLogin(context, studentId, password, fcmToken)
                         .then((result) async {
@@ -353,7 +358,7 @@ class _LoginPageState extends State<LoginPage> {
                         }
                         // userRole 값에 따라 다른 페이지로 이동
                         if (result['role'] == 'ROLE_ADMIN') {
-                          Navigator.pushNamed(context, '/dashboard');
+                          Navigator.pushNamed(context, '/homepage');
                         } else if (result['role'] == 'ROLE_USER') {
                           // techStack 값이 null이거나 값이 비어있는 경우
                           if (result['techStack'] == null ||

--- a/frontend/lib/screens/totalBoard_screen.dart
+++ b/frontend/lib/screens/totalBoard_screen.dart
@@ -1,0 +1,106 @@
+import 'package:flutter/material.dart';
+import 'package:frontend/all/providers/announcement_provider.dart';
+import 'package:frontend/screens/write_screen.dart';
+import 'package:frontend/widgets/boardAppbar_widget.dart';
+import 'package:frontend/widgets/board_widget.dart';
+import 'package:provider/provider.dart';
+
+class TotalBoardPage extends StatefulWidget {
+  const TotalBoardPage({super.key});
+
+  @override
+  State<TotalBoardPage> createState() => _TotalBoardPageState();
+}
+
+enum PopUpItem { popUpItem1, popUpItem2, popUpItem3 }
+
+class _TotalBoardPageState extends State<TotalBoardPage> {
+  @override
+  void initState() {
+    super.initState();
+    // listen: false를 사용하여 initState에서 Provider를 호출
+    // addPostFrameCallback 사용하는 이유 : initState에서 직접 Provider.of를 호출할 때 context가 아직 완전히 준비되지 않았기 때문에 발생할 수 있는 에러를 방지
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      Provider.of<AnnouncementProvider>(context, listen: false)
+          .fetchAllBoards();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final boardList = Provider.of<AnnouncementProvider>(context).boardList;
+    print('boardList: $boardList');
+
+    return Scaffold(
+      appBar: const BoardAppbar(),
+      body: Padding(
+        padding: const EdgeInsets.symmetric(
+          horizontal: 20,
+          vertical: 30.0,
+        ),
+        child: Column(
+          children: [
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                const Text(
+                  '전체 공지',
+                  style: TextStyle(
+                    fontSize: 20,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                // 팝업 메뉴 창
+                PopupMenuButton<PopUpItem>(
+                  color: const Color(0xFFEFF0F2),
+                  itemBuilder: (BuildContext context) {
+                    return [
+                      popUpItem('글쓰기', PopUpItem.popUpItem1, () {
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                              builder: (context) => const BoardWritePage()),
+                        );
+                      }),
+                      const PopupMenuDivider(),
+                      popUpItem('새로고침', PopUpItem.popUpItem2, () {}),
+                      const PopupMenuDivider(),
+                      popUpItem('숨김 관리', PopUpItem.popUpItem3, () {
+                        // 숨김 페이지로 이동
+                      }),
+                    ];
+                  },
+                  child: const Icon(Icons.more_vert),
+                ),
+              ],
+            ),
+            const SizedBox(height: 20),
+            boardList.isEmpty
+                ? const Center(child: CircularProgressIndicator()) // 로딩 중일 때
+                : Board(boardList: boardList),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+PopupMenuItem<PopUpItem> popUpItem(
+    String text, PopUpItem item, Function() onTap) {
+  return PopupMenuItem<PopUpItem>(
+    enabled: true, // 팝업메뉴 호출(ex: onTap()) 가능
+    onTap: onTap,
+    value: item,
+    height: 25,
+    child: Center(
+      child: Text(
+        text,
+        style: const TextStyle(
+          color: Color(0xFF787879),
+          fontSize: 13,
+          fontWeight: FontWeight.bold,
+        ),
+      ),
+    ),
+  );
+}

--- a/frontend/lib/screens/totalBoard_screen.dart
+++ b/frontend/lib/screens/totalBoard_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:frontend/all/providers/announcement_provider.dart';
 import 'package:frontend/screens/write_screen.dart';
+import 'package:frontend/services/login_services.dart';
 import 'package:frontend/widgets/boardAppbar_widget.dart';
 import 'package:frontend/widgets/board_widget.dart';
 import 'package:provider/provider.dart';
@@ -15,6 +16,8 @@ class TotalBoardPage extends StatefulWidget {
 enum PopUpItem { popUpItem1, popUpItem2, popUpItem3 }
 
 class _TotalBoardPageState extends State<TotalBoardPage> {
+  String userRole = '';
+
   @override
   void initState() {
     super.initState();
@@ -23,6 +26,15 @@ class _TotalBoardPageState extends State<TotalBoardPage> {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       Provider.of<AnnouncementProvider>(context, listen: false)
           .fetchAllBoards();
+    });
+  }
+
+  // 학번, 이름, 재적상태를 로드하는 메서드
+  Future<void> _loadCredentials() async {
+    final loginAPI = LoginAPI(); // LoginAPI 인스턴스 생성
+    final credentials = await loginAPI.loadCredentials(); // 저장된 자격증명 로드
+    setState(() {
+      userRole = credentials['userRole']; // 로그인 정보에 있는 level를 가져와 저장
     });
   }
 
@@ -55,19 +67,21 @@ class _TotalBoardPageState extends State<TotalBoardPage> {
                   color: const Color(0xFFEFF0F2),
                   itemBuilder: (BuildContext context) {
                     return [
-                      popUpItem('글쓰기', PopUpItem.popUpItem1, () {
-                        Navigator.push(
-                          context,
-                          MaterialPageRoute(
-                              builder: (context) => const BoardWritePage()),
-                        );
-                      }),
-                      const PopupMenuDivider(),
+                      if (userRole == 'ROLE_ADMIN')
+                        popUpItem('글쓰기', PopUpItem.popUpItem1, () {
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                                builder: (context) => const BoardWritePage()),
+                          );
+                        }),
+                      if (userRole == 'ROLE_ADMIN') const PopupMenuDivider(),
                       popUpItem('새로고침', PopUpItem.popUpItem2, () {}),
-                      const PopupMenuDivider(),
-                      popUpItem('숨김 관리', PopUpItem.popUpItem3, () {
-                        // 숨김 페이지로 이동
-                      }),
+                      if (userRole == 'ROLE_ADMIN') const PopupMenuDivider(),
+                      if (userRole == 'ROLE_ADMIN')
+                        popUpItem('숨김 관리', PopUpItem.popUpItem3, () {
+                          // 숨김 페이지로 이동
+                        }),
                     ];
                   },
                   child: const Icon(Icons.more_vert),

--- a/frontend/lib/services/login_services.dart
+++ b/frontend/lib/services/login_services.dart
@@ -49,12 +49,16 @@ class LoginAPI {
     final status = prefs.getString('status'); // 상태 불러오기
     final password = prefs.getString('password');
     final autoLogin = prefs.getBool('isAutoLogin') ?? false;
+    final level = prefs.getInt('level');
+    final userRole = prefs.getString('userRole');
     return {
       'studentId': studentId,
       'name': name, // 이름 추가
       'status': status, // 상태 추가
       'password': password,
       'isAutoLogin': autoLogin,
+      'level': level,
+      'userRole': userRole,
     };
   }
 
@@ -153,8 +157,8 @@ class LoginAPI {
   }
 
   // 로그인 API
-  Future<Map<String, dynamic>> handleLogin(
-      BuildContext context, String studentId, String password, String fcmToken) async {
+  Future<Map<String, dynamic>> handleLogin(BuildContext context,
+      String studentId, String password, String fcmToken) async {
     // HttpOverrides 설정
     HttpOverrides.global = MyHttpOverrides();
 
@@ -181,6 +185,7 @@ class LoginAPI {
         final memberExperience = responseData['memberExperiences'];
         final name = responseData['name'];
         final status = responseData['status'];
+        final level = responseData['level'];
 
         final accessToken = response.headers['access']; // 액세스 토큰 추출
         final setCookieHeader = response.headers['set-cookie'];
@@ -199,6 +204,7 @@ class LoginAPI {
           await prefs.setString('studentId', studentId); // 학번 저장
           await prefs.setString('name', name); // 이름 저장
           await prefs.setString('status', status); // 재적상태 저장
+          await prefs.setInt('level', level);
 
           final uri = Uri.parse(loginAddress);
           cookieJar.saveFromResponse(
@@ -210,11 +216,13 @@ class LoginAPI {
           final savedStudentId = prefs.getString('studentId');
           final savedName = prefs.getString('name');
           final savedStatus = prefs.getString('status');
+          final savedLevel = prefs.getInt('level');
           print('저장된 액세스 토큰: $savedAccessToken');
           print('저장된 리프레시 토큰: $savedRefreshToken');
           print('저장된 학번: $savedStudentId');
           print('저장된 이름: $savedName');
           print('저장된 상태: $savedStatus');
+          print('저장된 학년: $savedLevel');
 
           // memberExperience 배열에서 id 값 추출하여 저장
           final memberExperienceIds = (memberExperience as List)

--- a/frontend/lib/widgets/boardAppbar_widget.dart
+++ b/frontend/lib/widgets/boardAppbar_widget.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+
+// BoardAppbar 위젯 정의
+class BoardAppbar extends StatelessWidget implements PreferredSizeWidget {
+  const BoardAppbar({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return AppBar(
+      toolbarHeight: 70,
+      leadingWidth: 140,
+      leading: Padding(
+        padding: const EdgeInsets.only(left: 12.0),
+        child: IconButton(
+          onPressed: () {
+            Navigator.pushNamedAndRemoveUntil(
+                context, '/homepage', (route) => false);
+          },
+          icon: Image.asset('assets/images/logo.png'),
+          color: Colors.black,
+        ),
+      ),
+      actions: const [
+        Padding(
+          padding: EdgeInsets.only(right: 23.0),
+          child: Icon(
+            Icons.search,
+            size: 30,
+            color: Colors.black,
+          ),
+        ),
+        Padding(
+          padding: EdgeInsets.only(right: 23.0),
+          child: Icon(
+            Icons.add_alert,
+            size: 30,
+            color: Colors.black,
+          ),
+        ),
+        Padding(
+          padding: EdgeInsets.only(right: 23.0),
+          child: Icon(
+            Icons.account_circle,
+            size: 30,
+            color: Colors.black,
+          ),
+        ),
+      ],
+    );
+  }
+
+  // preferredSize를 재정의하여 AppBar의 크기를 지정
+  @override
+  Size get preferredSize => const Size.fromHeight(70);
+}

--- a/frontend/lib/widgets/board_widget.dart
+++ b/frontend/lib/widgets/board_widget.dart
@@ -2,13 +2,8 @@ import 'package:flutter/material.dart';
 
 class Board extends StatefulWidget {
   final List<Map<String, dynamic>> boardList;
-  final ValueChanged<bool> onChecked;
-  final bool isShowed; // 체크박스와 숨김/삭제 버튼 활성화 여부
-  const Board(
-      {required this.onChecked,
-      required this.boardList,
-      required this.isShowed,
-      super.key});
+
+  const Board({required this.boardList, super.key});
 
   @override
   State<Board> createState() => _BoardState();
@@ -22,118 +17,127 @@ class _BoardState extends State<Board> {
   Widget build(BuildContext context) {
     return Expanded(
       child: ListView.builder(
-        itemCount: widget.boardList.length,
-        itemBuilder: (context, index) {
-          final board = widget.boardList[index];
-          return Column(
-            children: [
-              GestureDetector(
-                onLongPress: () {
-                  setState(() {
-                    isPressed = !isPressed;
-                    widget.onChecked(isPressed); // isEdited 값 전달
-                  });
-                },
-                child: Card(
-                  color: const Color(0xFFFAFAFE),
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(15.0),
-                  ),
-                  elevation: 0.5,
-                  child: Container(
-                    padding: const EdgeInsets.symmetric(
-                        horizontal: 20.0, vertical: 18.0),
-                    width: double.infinity,
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
+          itemCount: widget.boardList.length,
+          itemBuilder: (context, index) {
+            final board = widget.boardList[index];
+
+            // 카테고리 변환
+            final category = _getCategoryName(board['announcementCategory']);
+
+            return Card(
+              color: const Color(0xFFFAFAFE),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(15.0),
+              ),
+              elevation: 0.5,
+              child: Container(
+                padding: const EdgeInsets.symmetric(
+                    horizontal: 20.0, vertical: 18.0),
+                width: double.infinity,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
                       children: [
                         Row(
-                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
                           children: [
                             Text(
-                              board['title'],
+                              board['announcementTitle'],
                               style: const TextStyle(
                                 fontSize: 16,
                                 fontWeight: FontWeight.bold,
                               ),
                             ),
-                            widget.isShowed
-                                // 숨김 / 삭제 체크박스
-                                ? SizedBox(
-                                    height: 20,
-                                    width: 20,
-                                    child: Checkbox(
-                                      value: board['isChecked'] ??
-                                          false, // isChecked가 null이면 기본값이 false 사용
-                                      onChanged: (value) {
-                                        setState(() {
-                                          board['isChecked'] = value;
-                                        });
-                                      },
-                                      shape: const CircleBorder(),
-                                      activeColor: const Color(0xFF7B88C2),
-                                    ),
-                                  )
-                                : Container(),
-                          ],
-                        ),
-                        const SizedBox(height: 7),
-                        Text(
-                          board['subtitle'],
-                          style: const TextStyle(
-                            fontWeight: FontWeight.bold,
-                          ),
-                        ),
-                        const SizedBox(height: 7),
-                        Text(
-                          board['content'],
-                          style: const TextStyle(
-                            fontWeight: FontWeight.bold,
-                            color: Color(0xFF7D7D7F),
-                          ),
-                        ),
-                        Row(
-                          mainAxisAlignment: MainAxisAlignment.end,
-                          children: [
-                            IconButton(
-                              padding: EdgeInsets.zero, // 패딩 설정
-                              constraints: const BoxConstraints(),
-                              onPressed: () {
-                                // 여기에 좋아요 api 구현
-
-                                setState(() {
-                                  board['isLiked'] = !board['isLiked'];
-
-                                  if (board['isLiked']) {
-                                    board['count'] += 1;
-                                  } else {
-                                    board['count'] -= 1;
-                                  }
-                                });
-                              },
-                              icon: Icon(
-                                board['isLiked']
-                                    ? Icons.favorite
-                                    : Icons.favorite_border,
-                                color: const Color(0xFFEA4E44),
+                            const SizedBox(width: 5),
+                            Text(
+                              category,
+                              style: const TextStyle(
+                                fontSize: 10,
+                                color: Color(0xFF7D7D7F),
                               ),
                             ),
-                            Text(
-                              '${board['count']}',
-                              style: const TextStyle(fontSize: 16),
-                            ),
                           ],
                         ),
+                        // SizedBox(
+                        //   height: 20,
+                        //   width: 20,
+                        //   child: Checkbox(
+                        //     value: board['isChecked'] ??
+                        //         false, // isChecked가 null이면 기본값이 false 사용
+                        //     onChanged: (value) {
+                        //       setState(() {
+                        //         board['isChecked'] = value;
+                        //       });
+                        //     },
+                        //     shape: const CircleBorder(),
+                        //     activeColor: const Color(0xFF7B88C2),
+                        //   ),
+                        // )
                       ],
                     ),
-                  ),
+                    const SizedBox(height: 7),
+                    Text(
+                      board['announcementContent'],
+                      style: const TextStyle(
+                        fontWeight: FontWeight.bold,
+                        fontSize: 14,
+                      ),
+                    ),
+                    const SizedBox(height: 7),
+
+                    // Row(
+                    //   mainAxisAlignment: MainAxisAlignment.end,
+                    //   children: [
+                    //     IconButton(
+                    //       padding: EdgeInsets.zero, // 패딩 설정
+                    //       constraints: const BoxConstraints(),
+                    //       onPressed: () {
+                    //         // 여기에 좋아요 api 구현
+
+                    //         setState(() {
+                    //           board['isLiked'] = !board['isLiked'];
+
+                    //           if (board['isLiked']) {
+                    //             board['count'] += 1;
+                    //           } else {
+                    //             board['count'] -= 1;
+                    //           }
+                    //         });
+                    //       },
+                    //       icon: Icon(
+                    //         board['isLiked']
+                    //             ? Icons.favorite
+                    //             : Icons.favorite_border,
+                    //         color: const Color(0xFFEA4E44),
+                    //       ),
+                    //     ),
+                    //     Text(
+                    //       '${board['count']}',
+                    //       style: const TextStyle(fontSize: 16),
+                    //     ),
+                    //   ],
+                    // ),
+                  ],
                 ),
               ),
-              const SizedBox(height: 13),
-            ],
-          );
-        },
-      ),
+            );
+          }),
     );
+  }
+
+  String _getCategoryName(String category) {
+    switch (category) {
+      case 'CONTEST':
+        return '경진대회';
+      case 'CORPORATE_TOUR':
+        return '기업';
+      case 'SEASONAL_SYSTEM':
+        return '계절제';
+      case 'ACADEMIC_ALL':
+        return '학년';
+      default:
+        return 'null'; // 변환되지 않은 경우 원래 값을 반환
+    }
   }
 }

--- a/frontend/lib/widgets/board_widget.dart
+++ b/frontend/lib/widgets/board_widget.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:frontend/services/login_services.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 class Board extends StatefulWidget {
   final List<Map<String, dynamic>> boardList;
@@ -10,118 +12,146 @@ class Board extends StatefulWidget {
 }
 
 class _BoardState extends State<Board> {
+  final prefs = SharedPreferences.getInstance();
   bool isPressed = false; // 길게 눌렀는지 여부
   int count = 4; // 좋아요 개수
+  int? level;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadCredentials(); // 학번을 로드하는 메서드 호출
+  }
+
+  // 학번, 이름, 재적상태를 로드하는 메서드
+  Future<void> _loadCredentials() async {
+    final loginAPI = LoginAPI(); // LoginAPI 인스턴스 생성
+    final credentials = await loginAPI.loadCredentials(); // 저장된 자격증명 로드
+    setState(() {
+      level = credentials['level']; // 로그인 정보에 있는 level를 가져와 저장
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
+    if (level == null) {
+      return const Center(child: Text('해당 학생의 공지가 없습니다.')); // 로딩 스피너 표시
+    }
+
     return Expanded(
       child: ListView.builder(
           itemCount: widget.boardList.length,
           itemBuilder: (context, index) {
             final board = widget.boardList[index];
 
-            // 카테고리 변환
-            final category = _getCategoryName(board['announcementCategory']);
+            final category =
+                _getCategoryName(board['announcementCategory']); // 카테고리 변환
+            final memberLevel = board['announcementLevel']; // 해당 공지 학년
 
-            return Card(
-              color: const Color(0xFFFAFAFE),
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(15.0),
-              ),
-              elevation: 0.5,
-              child: Container(
-                padding: const EdgeInsets.symmetric(
-                    horizontal: 20.0, vertical: 18.0),
-                width: double.infinity,
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                      children: [
-                        Row(
-                          children: [
-                            Text(
-                              board['announcementTitle'],
-                              style: const TextStyle(
-                                fontSize: 16,
-                                fontWeight: FontWeight.bold,
-                              ),
-                            ),
-                            const SizedBox(width: 5),
-                            Text(
-                              category,
-                              style: const TextStyle(
-                                fontSize: 10,
-                                color: Color(0xFF7D7D7F),
-                              ),
-                            ),
-                          ],
-                        ),
-                        // SizedBox(
-                        //   height: 20,
-                        //   width: 20,
-                        //   child: Checkbox(
-                        //     value: board['isChecked'] ??
-                        //         false, // isChecked가 null이면 기본값이 false 사용
-                        //     onChanged: (value) {
-                        //       setState(() {
-                        //         board['isChecked'] = value;
-                        //       });
-                        //     },
-                        //     shape: const CircleBorder(),
-                        //     activeColor: const Color(0xFF7B88C2),
-                        //   ),
-                        // )
-                      ],
-                    ),
-                    const SizedBox(height: 7),
-                    Text(
-                      board['announcementContent'],
-                      style: const TextStyle(
-                        fontWeight: FontWeight.bold,
-                        fontSize: 14,
-                      ),
-                    ),
-                    const SizedBox(height: 7),
-
-                    // Row(
-                    //   mainAxisAlignment: MainAxisAlignment.end,
-                    //   children: [
-                    //     IconButton(
-                    //       padding: EdgeInsets.zero, // 패딩 설정
-                    //       constraints: const BoxConstraints(),
-                    //       onPressed: () {
-                    //         // 여기에 좋아요 api 구현
-
-                    //         setState(() {
-                    //           board['isLiked'] = !board['isLiked'];
-
-                    //           if (board['isLiked']) {
-                    //             board['count'] += 1;
-                    //           } else {
-                    //             board['count'] -= 1;
-                    //           }
-                    //         });
-                    //       },
-                    //       icon: Icon(
-                    //         board['isLiked']
-                    //             ? Icons.favorite
-                    //             : Icons.favorite_border,
-                    //         color: const Color(0xFFEA4E44),
-                    //       ),
-                    //     ),
-                    //     Text(
-                    //       '${board['count']}',
-                    //       style: const TextStyle(fontSize: 16),
-                    //     ),
-                    //   ],
-                    // ),
-                  ],
+            // 로그인 정보의 학년(level)과 해당 공지의 학년(memberLevel)이 일치하면
+            // level이 0(관리자)이면 해당 공지를 보여주도록 설정
+            if (level == memberLevel || level == 0) {
+              return Card(
+                color: const Color(0xFFFAFAFE),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(15.0),
                 ),
-              ),
-            );
+                elevation: 0.5,
+                child: Container(
+                  padding: const EdgeInsets.symmetric(
+                      horizontal: 20.0, vertical: 18.0),
+                  width: double.infinity,
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: [
+                          Row(
+                            children: [
+                              Text(
+                                board['announcementTitle'],
+                                style: const TextStyle(
+                                  fontSize: 16,
+                                  fontWeight: FontWeight.bold,
+                                ),
+                              ),
+                              const SizedBox(width: 5),
+                              Text(
+                                category,
+                                style: const TextStyle(
+                                  fontSize: 10,
+                                  color: Color(0xFF7D7D7F),
+                                ),
+                              ),
+                            ],
+                          ),
+                          // SizedBox(
+                          //   height: 20,
+                          //   width: 20,
+                          //   child: Checkbox(
+                          //     value: board['isChecked'] ??
+                          //         false, // isChecked가 null이면 기본값이 false 사용
+                          //     onChanged: (value) {
+                          //       setState(() {
+                          //         board['isChecked'] = value;
+                          //       });
+                          //     },
+                          //     shape: const CircleBorder(),
+                          //     activeColor: const Color(0xFF7B88C2),
+                          //   ),
+                          // )
+                        ],
+                      ),
+                      const SizedBox(height: 7),
+                      Text(
+                        board['announcementContent'],
+                        style: const TextStyle(
+                          fontWeight: FontWeight.bold,
+                          fontSize: 14,
+                        ),
+                      ),
+                      const SizedBox(height: 7),
+
+                      // Row(
+                      //   mainAxisAlignment: MainAxisAlignment.end,
+                      //   children: [
+                      //     IconButton(
+                      //       padding: EdgeInsets.zero, // 패딩 설정
+                      //       constraints: const BoxConstraints(),
+                      //       onPressed: () {
+                      //         // 여기에 좋아요 api 구현
+
+                      //         setState(() {
+                      //           board['isLiked'] = !board['isLiked'];
+
+                      //           if (board['isLiked']) {
+                      //             board['count'] += 1;
+                      //           } else {
+                      //             board['count'] -= 1;
+                      //           }
+                      //         });
+                      //       },
+                      //       icon: Icon(
+                      //         board['isLiked']
+                      //             ? Icons.favorite
+                      //             : Icons.favorite_border,
+                      //         color: const Color(0xFFEA4E44),
+                      //       ),
+                      //     ),
+                      //     Text(
+                      //       '${board['count']}',
+                      //       style: const TextStyle(fontSize: 16),
+                      //     ),
+                      //   ],
+                      // ),
+                    ],
+                  ),
+                ),
+              );
+              return null;
+            }
+            return null;
           }),
     );
   }


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
#112

## ✨ 코드 변경 내용
<!-- 코드 변경에 대한 설명을 적어주세요 -->
### 게시글 전체 조회 API 연동 후 UI 구현
- 공지 전체를 볼 수 있는 페이지를 따로 생성
- 상단바를 공통 위젯으로 분리
- 초기값에 전체 조회 API 호출(addPostFrameCallback 사용)
- board 위젯을 만들어 get 메서드로 boardList를 불러 board 위젯으로 전달해 UI 구현
### 게시글 및 드롭메뉴 설정
- 로그인 정보의 학년 값대로 해당 공지글 보여주도록 설정
- 관리자나 학생에 따라 드롭메뉴 보여지도록 구현

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->
![Screenshot_1723183413](https://github.com/user-attachments/assets/de8a4802-37b0-415e-a75b-30c4f6162aaa)

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->