### PR TITLE
[Feat/#122] 게시글 삭제 API 연동

### DIFF
--- a/frontend/lib/all/providers/announcement_provider.dart
+++ b/frontend/lib/all/providers/announcement_provider.dart
@@ -128,6 +128,31 @@ class AnnouncementProvider with ChangeNotifier {
     }
   }
 
+  Future<void> deletedBoard(int announcementId) async {
+    try {
+      final accessToken = await getToken();
+      if (accessToken == null) {
+        throw Exception('엑세스 토큰을 찾을 수 없음');
+      }
+
+      final url = Uri.parse('$baseUrl/$announcementId');
+      final response = await http.delete(
+        url,
+        headers: {
+          'access': accessToken,
+        },
+      );
+
+      if (response.statusCode == 204) {
+        print('삭제 성공: ${response.body}');
+      } else {
+        print('삭제 실패: ${response.statusCode} - ${response.body}');
+      }
+    } catch (e) {
+      print(e.toString());
+    }
+  }
+
   // 카테고리별 조회
   Future<void> fetchCateBoard(String boardCategory) async {
     try {

--- a/frontend/lib/screens/contestBoard_screen.dart
+++ b/frontend/lib/screens/contestBoard_screen.dart
@@ -20,6 +20,8 @@ class _ContestBoardPageState extends State<ContestBoardPage> {
   String boardCategory = 'CONTEST';
   String userRole = '';
   String contestCategory = ''; // 경진대회 카테고리 버튼을 눌렀을 때 해당하는 카테고리를 저장하는 변수
+  bool isHidDel = false;
+  Map<String, dynamic>? selectedBoard;
 
   @override
   void initState() {
@@ -184,12 +186,81 @@ class _ContestBoardPageState extends State<ContestBoardPage> {
             Expanded(
               child: Board(
                 boardList: filteredBoardList,
-                total: false,
+                total: true, // true일 경우에는 특정 학년 게시글만 보여줌
+                onBoardSelected: (board) {
+                  setState(() {
+                    selectedBoard = board;
+                    isHidDel = !isHidDel;
+                  });
+                },
               ),
             ),
           ],
         ),
       ),
+
+      // 숨김/삭제 버튼(isEdited 값을 저장한 isHidDel)
+      bottomNavigationBar: isHidDel
+          ? Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                ElevatedButton(
+                  onPressed: () {},
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: const Color(0xFFFAFAFE),
+                    minimumSize: const Size(205, 75),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(0),
+                    ),
+                  ),
+                  child: const Text(
+                    '숨김',
+                    style: TextStyle(
+                      color: Color(0xFF7D7D7F),
+                      fontSize: 20,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+                ElevatedButton(
+                  onPressed: () async {
+                    if (selectedBoard != null) {
+                      print('id: ${selectedBoard!['id']}');
+                      await Provider.of<AnnouncementProvider>(context,
+                              listen: false)
+                          .deletedBoard(selectedBoard!['id']);
+
+                      if (context.mounted) {
+                        await Provider.of<AnnouncementProvider>(context,
+                                listen: false)
+                            .fetchCateBoard(boardCategory);
+                      }
+
+                      setState(() {
+                        selectedBoard = null;
+                        isHidDel = false;
+                      });
+                    }
+                  },
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: const Color(0xFFFAFAFE),
+                    minimumSize: const Size(205, 75),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(0),
+                    ),
+                  ),
+                  child: const Text(
+                    '삭제',
+                    style: TextStyle(
+                      color: Color(0xFF7D7D7F),
+                      fontSize: 20,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+              ],
+            )
+          : null,
     );
   }
 

--- a/frontend/lib/screens/corSeaBoard_screen.dart
+++ b/frontend/lib/screens/corSeaBoard_screen.dart
@@ -22,6 +22,9 @@ class _CorSeaBoardPageState extends State<CorSeaBoardPage> {
   List<Map<String, dynamic>> corporateBoardList = [];
   List<Map<String, dynamic>> seasonalBoardList = [];
 
+  bool isHidDel = false;
+  Map<String, dynamic>? selectedBoard;
+
   @override
   void initState() {
     super.initState();
@@ -117,15 +120,91 @@ class _CorSeaBoardPageState extends State<CorSeaBoardPage> {
               ],
             ),
             const SizedBox(height: 20),
-            sumList.isEmpty
-                ? const Text('해당 공지가 없습니다.')
-                : Board(
-                    boardList: sumList,
-                    total: false,
-                  ),
+            Expanded(
+              child: Board(
+                boardList: sumList,
+                total: true,
+                onBoardSelected: (board) {
+                  setState(() {
+                    selectedBoard = board;
+                    isHidDel = !isHidDel;
+                  });
+                },
+              ),
+            ),
           ],
         ),
       ),
+
+      // 숨김/삭제 버튼(isEdited 값을 저장한 isHidDel)
+      bottomNavigationBar: isHidDel
+          ? Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                ElevatedButton(
+                  onPressed: () {},
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: const Color(0xFFFAFAFE),
+                    minimumSize: const Size(205, 75),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(0),
+                    ),
+                  ),
+                  child: const Text(
+                    '숨김',
+                    style: TextStyle(
+                      color: Color(0xFF7D7D7F),
+                      fontSize: 20,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+                ElevatedButton(
+                  onPressed: () async {
+                    if (selectedBoard != null) {
+                      print('id: ${selectedBoard!['id']}');
+                      await Provider.of<AnnouncementProvider>(context,
+                              listen: false)
+                          .deletedBoard(selectedBoard!['id']);
+
+                      if (context.mounted) {
+                        await Provider.of<AnnouncementProvider>(context,
+                                listen: false)
+                            .fetchCateBoard(boardCategory[0]);
+                      }
+
+                      if (context.mounted) {
+                        // 두 번째 카테고리 API 호출
+                        await Provider.of<AnnouncementProvider>(context,
+                                listen: false)
+                            .fetchCateBoard(boardCategory[1]);
+                      }
+
+                      setState(() {
+                        selectedBoard = null;
+                        isHidDel = false;
+                      });
+                    }
+                  },
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: const Color(0xFFFAFAFE),
+                    minimumSize: const Size(205, 75),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(0),
+                    ),
+                  ),
+                  child: const Text(
+                    '삭제',
+                    style: TextStyle(
+                      color: Color(0xFF7D7D7F),
+                      fontSize: 20,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+              ],
+            )
+          : null,
     );
   }
 }

--- a/frontend/lib/screens/gradeBoard_screen.dart
+++ b/frontend/lib/screens/gradeBoard_screen.dart
@@ -19,6 +19,7 @@ class _GradeBoardPageState extends State<GradeBoardPage> {
   String selectedGrade = '1학년';
   bool isSelected = false;
   bool isHidDel = false; // 숨김 / 삭제 버튼 숨김 활성화 불리안
+  Map<String, dynamic>? selectedBoard; // 선택된 게시글을 저장할 변수
 
   String userRole = '';
   String boardCategory = 'ACADEMIC_ALL';
@@ -174,106 +175,81 @@ class _GradeBoardPageState extends State<GradeBoardPage> {
 
             Expanded(
               child: Board(
-                boardList: filteredBoardList,
-                total: true,
-              ),
+                  boardList: filteredBoardList,
+                  total: false,
+                  onBoardSelected: (board) {
+                    setState(() {
+                      selectedBoard = board;
+                      isHidDel = !isHidDel;
+                    });
+                  }),
             ),
           ],
         ),
       ),
 
       // 숨김/삭제 버튼(isEdited 값을 저장한 isHidDel)
-      // bottomNavigationBar: isHidDel
-      //     ? Row(
-      //         mainAxisAlignment: MainAxisAlignment.spaceBetween,
-      //         children: [
-      //           ElevatedButton(
-      //             onPressed: () {
-      //               setState(() {
-      //                 if (selectedGrade == '1학년') {
-      //                   // 리스트에서 isChecked 값이 true인 board만 hiddenList에 추가
-      //                   hiddenList.addAll(oneBoard // addAll : 리스트에 추가
-      //                       .where((board) =>
-      //                           board['isChecked'] ==
-      //                           true)); // where : 조건에 맞게 필터링
+      bottomNavigationBar: isHidDel
+          ? Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                ElevatedButton(
+                  onPressed: () {},
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: const Color(0xFFFAFAFE),
+                    minimumSize: const Size(205, 75),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(0),
+                    ),
+                  ),
+                  child: const Text(
+                    '숨김',
+                    style: TextStyle(
+                      color: Color(0xFF7D7D7F),
+                      fontSize: 20,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+                ElevatedButton(
+                  onPressed: () async {
+                    if (selectedBoard != null) {
+                      print('id: ${selectedBoard!['id']}');
+                      await Provider.of<AnnouncementProvider>(context,
+                              listen: false)
+                          .deletedBoard(selectedBoard!['id']);
 
-      //                   // isChecked 값이 true인 board만 BoardPage에서 제거
-      //                   oneBoard.removeWhere((board) =>
-      //                       board['isChecked'] ==
-      //                       true); // removeWhere : 조건에 맞게 제거
-      //                 } else if (selectedGrade == '2학년') {
-      //                   hiddenList.addAll(twoBoard
-      //                       .where((board) => board['isChecked'] == true));
-      //                   twoBoard
-      //                       .removeWhere((board) => board['isChecked'] == true);
-      //                 } else if (selectedGrade == '3학년') {
-      //                   hiddenList.addAll(threeBoard
-      //                       .where((board) => board['isChecked'] == true));
-      //                   threeBoard
-      //                       .removeWhere((board) => board['isChecked'] == true);
-      //                 } else if (selectedGrade == '4학년') {
-      //                   hiddenList.addAll(fourBoard
-      //                       .where((board) => board['isChecked'] == true));
-      //                   fourBoard
-      //                       .removeWhere((board) => board['isChecked'] == true);
-      //                 }
-      //                 isHidDel = false; // 숨김/삭제 버튼 비활성화
-      //               });
-      //             },
-      //             style: ElevatedButton.styleFrom(
-      //               backgroundColor: const Color(0xFFFAFAFE),
-      //               minimumSize: const Size(205, 75),
-      //               shape: RoundedRectangleBorder(
-      //                 borderRadius: BorderRadius.circular(0),
-      //               ),
-      //             ),
-      //             child: const Text(
-      //               '숨김',
-      //               style: TextStyle(
-      //                 color: Color(0xFF7D7D7F),
-      //                 fontSize: 20,
-      //                 fontWeight: FontWeight.bold,
-      //               ),
-      //             ),
-      //           ),
-      //           ElevatedButton(
-      //             onPressed: () {
-      //               // setState(() {
-      //               //   if (selectedGrade == '1학년') {
-      //               //     oneBoard
-      //               //         .removeWhere((board) => board['isChecked'] == true);
-      //               //   } else if (selectedGrade == '2학년') {
-      //               //     twoBoard
-      //               //         .removeWhere((board) => board['isChecked'] == true);
-      //               //   } else if (selectedGrade == '3학년') {
-      //               //     threeBoard
-      //               //         .removeWhere((board) => board['isChecked'] == true);
-      //               //   } else if (selectedGrade == '4학년') {
-      //               //     fourBoard
-      //               //         .removeWhere((board) => board['isChecked'] == true);
-      //               //   }
-      //               //   isHidDel = false; // 숨김/삭제 버튼 비활성화
-      //               // });
-      //             },
-      //             style: ElevatedButton.styleFrom(
-      //               backgroundColor: const Color(0xFFFAFAFE),
-      //               minimumSize: const Size(205, 75),
-      //               shape: RoundedRectangleBorder(
-      //                 borderRadius: BorderRadius.circular(0),
-      //               ),
-      //             ),
-      //             child: const Text(
-      //               '삭제',
-      //               style: TextStyle(
-      //                 color: Color(0xFF7D7D7F),
-      //                 fontSize: 20,
-      //                 fontWeight: FontWeight.bold,
-      //               ),
-      //             ),
-      //           ),
-      //         ],
-      //       )
-      //     : null,
+                      if (context.mounted) {
+                        await Provider.of<AnnouncementProvider>(context,
+                                listen: false)
+                            .fetchCateBoard(boardCategory);
+                      }
+
+                      setState(() {
+                        isHidDel = true;
+                        selectedBoard = null;
+                      });
+                    }
+                  },
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: const Color(0xFFFAFAFE),
+                    minimumSize: const Size(205, 75),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(0),
+                    ),
+                  ),
+                  child: const Text(
+                    '삭제',
+                    style: TextStyle(
+                      color: Color(0xFF7D7D7F),
+                      fontSize: 20,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+              ],
+            )
+          : null,
     );
   }
 }

--- a/frontend/lib/screens/login_screen.dart
+++ b/frontend/lib/screens/login_screen.dart
@@ -358,7 +358,7 @@ class _LoginPageState extends State<LoginPage> {
                         }
                         // userRole 값에 따라 다른 페이지로 이동
                         if (result['role'] == 'ROLE_ADMIN') {
-                          Navigator.pushNamed(context, '/dashboard');
+                          Navigator.pushNamed(context, '/homepage');
                         } else if (result['role'] == 'ROLE_USER') {
                           // techStack 값이 null이거나 값이 비어있는 경우
                           if (result['techStack'] == null ||

--- a/frontend/lib/screens/totalBoard_screen.dart
+++ b/frontend/lib/screens/totalBoard_screen.dart
@@ -17,6 +17,8 @@ enum PopUpItem { popUpItem1, popUpItem2, popUpItem3 }
 
 class _TotalBoardPageState extends State<TotalBoardPage> {
   String userRole = '';
+  bool isHidDel = false;
+  Map<String, dynamic>? selectedBoard; // 선택된 게시글을 저장할 변수
 
   @override
   void initState() {
@@ -90,15 +92,83 @@ class _TotalBoardPageState extends State<TotalBoardPage> {
               ],
             ),
             const SizedBox(height: 20),
-            boardList.isEmpty
-                ? const Center(child: CircularProgressIndicator()) // 로딩 중일 때
-                : Board(
-                    boardList: boardList,
-                    total: false,
-                  ),
+            Expanded(
+              child: Board(
+                boardList: boardList,
+                total: true,
+                onBoardSelected: (board) {
+                  setState(() {
+                    selectedBoard = board;
+                    isHidDel = !isHidDel; // 숨김/삭제 버튼 표시
+                  });
+                },
+              ),
+            ),
           ],
         ),
       ),
+      // 숨김/삭제 버튼(isEdited 값을 저장한 isHidDel)
+      bottomNavigationBar: isHidDel
+          ? Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                ElevatedButton(
+                  onPressed: () {},
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: const Color(0xFFFAFAFE),
+                    minimumSize: const Size(205, 75),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(0),
+                    ),
+                  ),
+                  child: const Text(
+                    '숨김',
+                    style: TextStyle(
+                      color: Color(0xFF7D7D7F),
+                      fontSize: 20,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+                ElevatedButton(
+                  onPressed: () async {
+                    if (selectedBoard != null) {
+                      print('id: ${selectedBoard!['id']}');
+                      await Provider.of<AnnouncementProvider>(context,
+                              listen: false)
+                          .deletedBoard(selectedBoard!['id']);
+
+                      // 전체 boardList를 다시 불러옴
+                      if (context.mounted) {
+                        await Provider.of<AnnouncementProvider>(context,
+                                listen: false)
+                            .fetchAllBoards();
+                      }
+                      setState(() {
+                        isHidDel = false; // 숨김/삭제 버튼 숨기기
+                        selectedBoard = null; // 선택된 게시글 초기화
+                      });
+                    }
+                  },
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: const Color(0xFFFAFAFE),
+                    minimumSize: const Size(205, 75),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(0),
+                    ),
+                  ),
+                  child: const Text(
+                    '삭제',
+                    style: TextStyle(
+                      color: Color(0xFF7D7D7F),
+                      fontSize: 20,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+              ],
+            )
+          : null,
     );
   }
 }

--- a/frontend/lib/services/login_services.dart
+++ b/frontend/lib/services/login_services.dart
@@ -16,9 +16,13 @@ class LoginAPI {
   //     'https://reminder.sungkyul.ac.kr/api/v1/reissue';
   // static const logoutAddress = 'https://reminder.sungkyul.ac.kr/api/v1/logout';
 
-  static const loginAddress = 'http://127.0.0.1:9000/login';
-  static const tokenRefreshAddress = 'http://127.0.0.1:9000/api/v1/reissue';
-  static const logoutAddress = 'http://127.0.0.1:9000/api/v1/logout';
+  static const loginAddress = 'http://10.0.2.2:9000/login';
+  static const tokenRefreshAddress = 'http://10.0.2.2:9000/api/v1/reissue';
+  static const logoutAddress = 'http://10.0.2.2:9000/api/v1/logout';
+
+  // static const loginAddress = 'http://127.0.0.1:9000/login';
+  // static const tokenRefreshAddress = 'http://127.0.0.1:9000/api/v1/reissue';
+  // static const logoutAddress = 'http://127.0.0.1:9000/api/v1/logout';
 
   LoginAPI() {
     _initCookieJar();

--- a/frontend/lib/services/profile_service.dart
+++ b/frontend/lib/services/profile_service.dart
@@ -12,7 +12,8 @@ class ProfileService {
 
   // final String baseUrl =
   //     'https://reminder.sungkyul.ac.kr/api/v1/member-profile';
-  final String baseUrl = 'http://127.0.0.1:9000/api/v1/member-profile';
+  final String baseUrl = 'http://10.0.2.2:9000/api/v1/member-profile';
+  // final String baseUrl = 'http://127.0.0.1:9000/api/v1/member-profile';
 
   // 프로필 생성 API
   Future<int> createProfile(Profile profile) async {

--- a/frontend/lib/widgets/board_widget.dart
+++ b/frontend/lib/widgets/board_widget.dart
@@ -6,8 +6,13 @@ class Board extends StatefulWidget {
   final List<Map<String, dynamic>> boardList;
   final bool
       total; // level과 memberLevel이 맞는 공지사항만 필터링하는 작업을 할 것인지 여부(true일 때 필터링 작업 진행)
+  final Function(Map<String, dynamic> board)? onBoardSelected; // 선택된 게시글 콜백 함수
 
-  const Board({required this.boardList, required this.total, super.key});
+  const Board(
+      {required this.boardList,
+      required this.total,
+      this.onBoardSelected,
+      super.key});
 
   @override
   State<Board> createState() => _BoardState();
@@ -19,6 +24,7 @@ class _BoardState extends State<Board> {
   int count = 4; // 좋아요 개수
   int? level;
   List<Map<String, dynamic>> filteredBoardList = [];
+  int? selectedBoardIndex; // 선택된 게시글의 인덱스를 저장할 변수
 
   @override
   void initState() {
@@ -59,6 +65,17 @@ class _BoardState extends State<Board> {
           ),
         );
       }
+    } else if (widget.boardList.isEmpty) {
+      return const Center(
+        child: Text(
+          '해당 학생의 공지가 없습니다.',
+          style: TextStyle(
+            fontSize: 16,
+            fontWeight: FontWeight.bold,
+            color: Colors.black54,
+          ),
+        ),
+      );
     }
 
     // 필터링된 공지사항 리스트를 화면에 표시
@@ -70,56 +87,74 @@ class _BoardState extends State<Board> {
         final board =
             widget.total ? filteredBoardList[index] : widget.boardList[index];
         final category = _getCategoryName(board['announcementCategory']);
+        final isSelected = selectedBoardIndex == index; // 현재 게시글이 선택된 게시글인지 확인
 
         return Column(
           children: [
-            Card(
-              color: const Color(0xFFFAFAFE),
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(15.0),
-              ),
-              elevation: 0.5,
-              child: Container(
-                padding: const EdgeInsets.symmetric(
-                    horizontal: 20.0, vertical: 18.0),
-                width: double.infinity,
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                      children: [
-                        Row(
-                          children: [
-                            Text(
-                              board['announcementTitle'],
-                              style: const TextStyle(
-                                fontSize: 16,
-                                fontWeight: FontWeight.bold,
+            GestureDetector(
+              onLongPress: () async {
+                setState(() {
+                  selectedBoardIndex = index; // 선택된 게시글의 인덱스를 저장
+                });
+                if (widget.onBoardSelected != null) {
+                  widget.onBoardSelected!(board); // 선택된 게시글 콜백 호출
+                }
+                print('selectedBoard: ${board['announcementTitle']}');
+              },
+              child: Card(
+                color: const Color(0xFFFAFAFE),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(15.0),
+                  // side: BorderSide(
+                  //   color: isSelected
+                  //       ? Colors.blue
+                  //       : Colors.transparent, // 선택된 경우 테두리 색상 적용
+                  //   width: 1.0,
+                  // ),
+                ),
+                elevation: 0.5,
+                child: Container(
+                  padding: const EdgeInsets.symmetric(
+                      horizontal: 20.0, vertical: 18.0),
+                  width: double.infinity,
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: [
+                          Row(
+                            children: [
+                              Text(
+                                board['announcementTitle'],
+                                style: const TextStyle(
+                                  fontSize: 16,
+                                  fontWeight: FontWeight.bold,
+                                ),
                               ),
-                            ),
-                            const SizedBox(width: 5),
-                            Text(
-                              category,
-                              style: const TextStyle(
-                                fontSize: 10,
-                                color: Color(0xFF7D7D7F),
+                              const SizedBox(width: 5),
+                              Text(
+                                category,
+                                style: const TextStyle(
+                                  fontSize: 10,
+                                  color: Color(0xFF7D7D7F),
+                                ),
                               ),
-                            ),
-                          ],
-                        ),
-                      ],
-                    ),
-                    const SizedBox(height: 7),
-                    Text(
-                      board['announcementContent'],
-                      style: const TextStyle(
-                        fontWeight: FontWeight.bold,
-                        fontSize: 14,
+                            ],
+                          ),
+                        ],
                       ),
-                    ),
-                    const SizedBox(height: 7),
-                  ],
+                      const SizedBox(height: 7),
+                      Text(
+                        board['announcementContent'],
+                        style: const TextStyle(
+                          fontWeight: FontWeight.bold,
+                          fontSize: 14,
+                        ),
+                      ),
+                      const SizedBox(height: 7),
+                    ],
+                  ),
                 ),
               ),
             ),


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
#122

## ✨ 코드 변경 내용
<!-- 코드 변경에 대한 설명을 적어주세요 -->
### 게시글 삭제 API 연동
- board 위젯에 onBoardSelected 파라미터를 추가해 선택된 게시글을 받은 후 선택된 게시글을 저장할 변수에 저장
- onLongPressed로 isHidDel 상태값을 설정해 true일 경우 bottomNavigationBar 생기게 구현
- 삭제 버튼 내에 삭제 API 호출 뒤 바로 업데이트된 boardList를 보여주기 위해 조회도 호출

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->
### 삭제 전
<img width="950" alt="스크린샷 2024-08-11 오후 5 52 11" src="https://github.com/user-attachments/assets/1d7e1ce5-6b68-4612-a668-b8f52b3ba856">

### 삭제 후
<img width="238" alt="스크린샷 2024-08-11 오후 5 52 19" src="https://github.com/user-attachments/assets/8dce158b-115f-40f6-b1ba-b2b7844f597f">

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
