### PR TITLE
[Feat/#130] 게시글 보이기 API 연동

### DIFF
--- a/frontend/lib/all/providers/announcement_provider.dart
+++ b/frontend/lib/all/providers/announcement_provider.dart
@@ -99,6 +99,35 @@ class AnnouncementProvider with ChangeNotifier {
     }
   }
 
+  // 게시글 보이기
+  Future<void> showedBoard(int announcementId) async {
+    try {
+      final accessToken = await getToken();
+      if (accessToken == null) {
+        throw Exception('엑세스 토큰을 찾을 수 없음');
+      }
+
+      final url = Uri.parse('$baseUrl/show/$announcementId');
+      final response = await http.put(
+        url,
+        headers: {
+          'access': accessToken,
+        },
+      );
+
+      final utf8Response = utf8.decode(response.bodyBytes);
+      final jsonResponse = jsonDecode(utf8Response);
+
+      if (response.statusCode == 200) {
+        print('숨김 보이기 성공: $jsonResponse');
+      } else {
+        print('숨김 보이기 실패: ${response.body}');
+      }
+    } catch (e) {
+      print(e.toString());
+    }
+  }
+
   // 하나의 게시글 조회
   Future<void> fetchOneBoard(int announcementId) async {
     try {

--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -10,6 +10,7 @@ import 'package:frontend/screens/contestBoard_screen.dart';
 import 'package:frontend/screens/editField_screen.dart';
 import 'package:frontend/screens/editTool_screen.dart';
 import 'package:frontend/screens/hiddenList_screen.dart';
+import 'package:frontend/screens/totalBoard_screen.dart';
 import 'package:frontend/screens/write_screen.dart';
 import 'package:get/get.dart';
 import 'package:frontend/admin/providers/admin_provider.dart';
@@ -193,12 +194,13 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
         '/dashboard': (context) => const DashBoardPage(),
         '/edit-field': (context) => const EditFieldPage(),
         '/edit-tool': (context) => const EditToolPage(),
+        '/total-board': (context) => const TotalBoardPage(),
         '/write-board': (context) => const BoardWritePage(),
         '/contest-board': (context) => const ContestBoardPage(),
         '/grade-board': (context) => const GradeBoardPage(),
         '/corSea-board': (context) => const CorSeaBoardPage(),
         '/detail-board': (context) => BoardDetailPage(),
-        '/hidden-board': (context) => const HiddenPage(),
+        '/hidden-board': (context) => HiddenPage(),
       },
     );
   }

--- a/frontend/lib/screens/contestBoard_screen.dart
+++ b/frontend/lib/screens/contestBoard_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:frontend/all/providers/announcement_provider.dart';
+import 'package:frontend/screens/hiddenList_screen.dart';
 import 'package:frontend/screens/write_screen.dart';
 import 'package:frontend/services/login_services.dart';
 import 'package:frontend/widgets/boardAppbar_widget.dart';
@@ -125,7 +126,13 @@ class _ContestBoardPageState extends State<ContestBoardPage> {
                       if (userRole == 'ROLE_ADMIN') const PopupMenuDivider(),
                       if (userRole == 'ROLE_ADMIN')
                         popUpItem('숨김 관리', PopUpItem.popUpItem3, () {
-                          Navigator.pushNamed(context, '/hidden-board');
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder: (context) =>
+                                  HiddenPage(category: 'CONTEST'),
+                            ),
+                          );
                         }),
                     ];
                   },

--- a/frontend/lib/screens/corSeaBoard_screen.dart
+++ b/frontend/lib/screens/corSeaBoard_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:frontend/all/providers/announcement_provider.dart';
+import 'package:frontend/screens/hiddenList_screen.dart';
 import 'package:frontend/screens/write_screen.dart';
 import 'package:frontend/services/login_services.dart';
 import 'package:frontend/widgets/boardAppbar_widget.dart';
@@ -110,7 +111,13 @@ class _CorSeaBoardPageState extends State<CorSeaBoardPage> {
                       if (userRole == 'ROLE_ADMIN') const PopupMenuDivider(),
                       if (userRole == 'ROLE_ADMIN')
                         popUpItem('숨김 관리', PopUpItem.popUpItem3, () {
-                          Navigator.pushNamed(context, '/hidden-page');
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder: (context) =>
+                                  HiddenPage(category: 'CORSEA'),
+                            ),
+                          );
                         }),
                     ];
                   },

--- a/frontend/lib/screens/gradeBoard_screen.dart
+++ b/frontend/lib/screens/gradeBoard_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:frontend/all/providers/announcement_provider.dart';
+import 'package:frontend/screens/hiddenList_screen.dart';
 import 'package:frontend/screens/write_screen.dart';
 import 'package:frontend/services/login_services.dart';
 import 'package:frontend/widgets/boardAppbar_widget.dart';
@@ -118,7 +119,13 @@ class _GradeBoardPageState extends State<GradeBoardPage> {
                       if (userRole == 'ROLE_ADMIN') const PopupMenuDivider(),
                       if (userRole == 'ROLE_ADMIN')
                         popUpItem('숨김 관리', PopUpItem.popUpItem3, () {
-                          Navigator.pushNamed(context, '/hidden-board');
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder: (context) =>
+                                  HiddenPage(category: 'ACADEMIC_ALL'),
+                            ),
+                          );
                         }),
                     ];
                   },

--- a/frontend/lib/screens/hiddenList_screen.dart
+++ b/frontend/lib/screens/hiddenList_screen.dart
@@ -4,15 +4,19 @@ import 'package:frontend/widgets/board_widget.dart';
 import 'package:provider/provider.dart';
 
 class HiddenPage extends StatefulWidget {
-  const HiddenPage({super.key});
+  String? category;
+  HiddenPage({this.category, super.key});
 
   @override
   State<HiddenPage> createState() => _HiddenPageState();
 }
 
 class _HiddenPageState extends State<HiddenPage> {
+  String? category;
   bool isShowed = false;
   List<Map<String, dynamic>> selectedHiddenItems = [];
+  Map<String, dynamic>? selectedBoard;
+  bool isHidDel = false;
 
   @override
   void initState() {
@@ -34,7 +38,15 @@ class _HiddenPageState extends State<HiddenPage> {
         toolbarHeight: 70,
         leading: BackButton(
           onPressed: () {
-            Navigator.pop(context);
+            if (widget.category == 'TOTAL') {
+              Navigator.popAndPushNamed(context, '/total-board');
+            } else if (widget.category == 'ACADEMIC_ALL') {
+              Navigator.popAndPushNamed(context, '/grade-board');
+            } else if (widget.category == 'CONTEST') {
+              Navigator.popAndPushNamed(context, '/contest-board');
+            } else if (widget.category == 'CORSEA') {
+              Navigator.popAndPushNamed(context, '/corSea-board');
+            }
           },
           color: Colors.black,
         ),
@@ -85,44 +97,54 @@ class _HiddenPageState extends State<HiddenPage> {
               child: Board(
                 boardList: hiddenList,
                 total: false,
+                onBoardSelected: (board) {
+                  setState(() {
+                    selectedBoard = board;
+                    isHidDel = !isHidDel;
+                  });
+                },
               ),
             ),
           ],
         ),
       ),
-      bottomNavigationBar: ElevatedButton(
-        onPressed: () {
-          // // selectedHiddenItems에 있는 항목들을 hiddenList에 제거해 숨김 목록 취소
-          // widget.onUnhide!(selectedHiddenItems);
-          // setState(() {
-          //   widget.hiddenList!.removeWhere((item) =>
-          //       selectedHiddenItems.contains(
-          //           item)); // selectedHiddenItems에 있는 항목들을 필터링해 숨김 목록 화면에 제거
-          //   // 그 이후에 selectedHiddenItems에 있는 항목들 제거
-          //   selectedHiddenItems.clear();
-          //   isShowed = false;
-          // });
-        },
-        style: ElevatedButton.styleFrom(
-          backgroundColor: selectedHiddenItems.isNotEmpty
-              ? const Color(0xFF2B72E7)
-              : const Color(0xFFFAFAFE),
-          minimumSize: const Size(205, 75),
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(0),
-          ),
-        ),
-        child: Text(
-          '숨김 해제',
-          style: TextStyle(
-            color: selectedHiddenItems.isNotEmpty
-                ? Colors.white
-                : Colors.black.withOpacity(0.5),
-            fontSize: 20,
-            fontWeight: FontWeight.bold,
-          ),
-        ),
-      ),
+      bottomNavigationBar: isHidDel
+          ? ElevatedButton(
+              onPressed: () async {
+                if (selectedBoard != null) {
+                  print('selectedBoardId: ${selectedBoard!['id']}');
+                  await Provider.of<AnnouncementProvider>(context,
+                          listen: false)
+                      .showedBoard(selectedBoard!['id']);
+
+                  if (context.mounted) {
+                    await Provider.of<AnnouncementProvider>(context,
+                            listen: false)
+                        .fetchHiddenBoard();
+                  }
+                }
+              },
+              style: ElevatedButton.styleFrom(
+                backgroundColor: selectedHiddenItems.isNotEmpty
+                    ? const Color(0xFF2B72E7)
+                    : const Color(0xFFFAFAFE),
+                minimumSize: const Size(205, 75),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(0),
+                ),
+              ),
+              child: Text(
+                '숨김 해제',
+                style: TextStyle(
+                  color: selectedHiddenItems.isNotEmpty
+                      ? Colors.white
+                      : Colors.black.withOpacity(0.5),
+                  fontSize: 20,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            )
+          : null,
     );
   }
 }

--- a/frontend/lib/screens/totalBoard_screen.dart
+++ b/frontend/lib/screens/totalBoard_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:frontend/all/providers/announcement_provider.dart';
+import 'package:frontend/screens/hiddenList_screen.dart';
 import 'package:frontend/screens/write_screen.dart';
 import 'package:frontend/services/login_services.dart';
 import 'package:frontend/widgets/boardAppbar_widget.dart';
@@ -81,7 +82,13 @@ class _TotalBoardPageState extends State<TotalBoardPage> {
                       if (userRole == 'ROLE_ADMIN') const PopupMenuDivider(),
                       if (userRole == 'ROLE_ADMIN')
                         popUpItem('숨김 관리', PopUpItem.popUpItem3, () {
-                          Navigator.pushNamed(context, '/hidden-board');
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder: (context) =>
+                                  HiddenPage(category: 'TOTAL'),
+                            ),
+                          );
                         }),
                     ];
                   },

--- a/frontend/lib/widgets/board_widget.dart
+++ b/frontend/lib/widgets/board_widget.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:frontend/all/providers/announcement_provider.dart';
+import 'package:frontend/screens/boardDetail_screen.dart';
 import 'package:frontend/services/login_services.dart';
 import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -99,14 +100,17 @@ class _BoardState extends State<Board> {
             GestureDetector(
               // 게시글 들어갈 때
               onTap: () async {
-                // await Provider.of<AnnouncementProvider>(context, listen: false)
-                //     .fetchOneBoard(board['id']);
+                await Provider.of<AnnouncementProvider>(context, listen: false)
+                    .fetchOneBoard(board['id']);
 
                 if (context.mounted) {
-                  Navigator.pushNamed(
+                  Navigator.push(
                     context,
-                    '/detail-board',
-                    arguments: board['id'],
+                    MaterialPageRoute(
+                      builder: (context) => BoardDetailPage(
+                        announcementId: board['id'],
+                      ),
+                    ),
                   );
                 }
               },


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
#30

## ✨ 코드 변경 내용
<!-- 코드 변경에 대한 설명을 적어주세요 -->
### 게시글 보이기 API 연동
- 숨김 관리 페이지로 이동할 때 category 값을 전달해 category값에 따라 이동하는 페이지가 다르게 작성
- 숨김과 동일하게 board_widget에서 선택한 게시글을 받아서 API 메서드 호출

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->
### 숨김 해제 전
<img width="964" alt="스크린샷 2024-08-12 오후 12 05 29" src="https://github.com/user-attachments/assets/28f7e8b0-6f62-4cfd-9654-b368488516fd">

### 숨김 해제 후
<img width="673" alt="스크린샷 2024-08-12 오후 12 05 37" src="https://github.com/user-attachments/assets/532221e0-3aaa-4629-960d-b08ae7f74e36">

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
