### PR TITLE
[feat :#154] 팀원 신청글 삭제 API 연동

### DIFF
--- a/frontend/lib/providers/teamApply_provider.dart
+++ b/frontend/lib/providers/teamApply_provider.dart
@@ -46,4 +46,19 @@ class TeamApplyProvider with ChangeNotifier {
       print(e);
     }
   }
+
+  // 팀원 신청글 삭제
+  Future<void> deleteTeamApply(int applicationId) async {
+    try {
+      await service.deleteTeamApply(applicationId);
+      print(
+          'Application ID: $applicationId deleted successfully'); // 디버깅을 위한 로그
+
+      // 로컬 리스트에서 해당 신청글을 삭제하고 리스너들에게 알림
+      teamApplys.removeWhere((app) => app.id == applicationId);
+      notifyListeners();
+    } catch (e) {
+      print(e);
+    }
+  }
 }

--- a/frontend/lib/screens/recruitDetail_screen.dart
+++ b/frontend/lib/screens/recruitDetail_screen.dart
@@ -122,6 +122,25 @@ class _RecruitDetailPageState extends State<RecruitDetailPage> {
     }
   }
 
+  // 신청글 삭제하는 함수
+  void _deleteContent(int index) async {
+    try {
+      final apply = applyList[index];
+      final int applicationId = apply['id'];
+
+      final teamApplyService = TeamApplyService();
+      await teamApplyService.deleteTeamApply(applicationId);
+
+      setState(() {
+        applyList.removeAt(index); // 로컬 리스트에서 해당 신청글을 제거
+      });
+
+      print('신청글 삭제 성공: $applicationId');
+    } catch (e) {
+      print('신청글 삭제 실패: $e');
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final makeTeam = widget.makeTeam;
@@ -567,6 +586,8 @@ class _RecruitDetailPageState extends State<RecruitDetailPage> {
                                           applyList[index]
                                               ['applicationContent'],
                                           index);
+                                    } else if (item == '삭제') {
+                                      _deleteContent(index);
                                     }
                                   },
                                   itemBuilder: (BuildContext context) {

--- a/frontend/lib/services/teamApply_service.dart
+++ b/frontend/lib/services/teamApply_service.dart
@@ -99,4 +99,30 @@ class TeamApplyService {
       throw Exception('팀원 신청글 수정 실패: ${response.body}');
     }
   }
+
+  // 팀원 신청글 삭제 API
+  Future<void> deleteTeamApply(int applicationId) async {
+    final String baseUrl =
+        'http://127.0.0.1:9000/api/v1/recruitment/team-application/$applicationId';
+
+    final token = await getToken();
+    if (token == null) {
+      throw Exception('Access token을 찾을 수 없습니다.');
+    }
+
+    final response = await http.delete(
+      Uri.parse(baseUrl),
+      headers: <String, String>{
+        'Content-Type': 'application/json',
+        'access': token,
+      },
+    );
+
+    if (response.statusCode == 200) {
+      final responseData = jsonDecode(utf8.decode(response.bodyBytes));
+      print('팀원 신청글 삭제 성공: $responseData');
+    } else {
+      throw Exception('팀원 신청글 삭제 실패: ${response.body}');
+    }
+  }
 }


### PR DESCRIPTION
## 📌 관련 이슈
#154

## ✨ 코드 변경 내용
- 현재 사용자가 댓글 작성자인 경우에만 팝업 메뉴를 보여주는 상태에서 삭제 popupItem 클릭 시 삭제되도록 구현
- 신청글 삭제하는 함수 _deleteContent 선언하여 관리

## 📸 스크린샷(선택)
<img width="573" alt="스크린샷 2024-08-18 오전 1 59 00" src="https://github.com/user-attachments/assets/38af1db2-02d2-402e-9db2-5e2aece2474d">
<img width="844" alt="스크린샷 2024-08-18 오전 1 59 26" src="https://github.com/user-attachments/assets/24302fad-6cc4-4cfc-a358-cff0478bea39">
![Simulator Screenshot - iPhone 15 Pro Max - 2024-08-18 at 01 59 33](https://github.com/user-attachments/assets/38cfbb37-1fad-4f7e-9204-72dacbe694ed)


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
