### PR TITLE
[Feat/#149] 투표 종료 API 연동

### DIFF
--- a/frontend/lib/models/vote_model.dart
+++ b/frontend/lib/models/vote_model.dart
@@ -4,8 +4,10 @@ class Vote {
   bool? repetition;
   bool? additional;
   int? announcementId;
-  String? endTime;
+  String? endDateTime;
+  bool? voteEnded;
   List<int>? voteItemIds;
+  List<Map<String, dynamic>>? voteItems;
 
   Vote({
     this.id,
@@ -13,8 +15,10 @@ class Vote {
     required this.repetition,
     required this.additional,
     required this.announcementId,
-    required this.endTime,
+    required this.endDateTime,
+    this.voteEnded,
     this.voteItemIds,
+    this.voteItems,
   });
 
   // 데이터를 가져올 때 사용
@@ -27,21 +31,20 @@ class Vote {
       announcementId: json['announcementId'],
 
       // endTime이 List<int> 형식으로 전달되는 경우, 이를 DateTime으로 변환 후 String으로 변환
-      endTime: json['endTime']
-              is List<dynamic> // json['endTime']이 List<dynamic> 타입인지 확인
-          ? DateTime(
-              json['endTime'][0],
-              json['endTime'][1],
-              json['endTime'][2],
-              json['endTime'][3],
-              json['endTime'][4],
-            ).toIso8601String() // List<int>로 변환하고 DateTime 객체로 변환
-          : json['endTime'] as String?, // DateTime 객체를 ISO 8601 형식의 String으로 변환
+      endDateTime: json['endDateTime']
+          as String?, // DateTime 객체를 ISO 8601 형식의 String으로 변환
+
+      voteEnded: json['voteEnded'],
 
       // 전달받은 json 맵에서 각 필드를 추출하여 Vote 객체 생성
       // voteItemIds는 List<dynamic> 형식으로 전달될 수 있기 때문에, 이를 List<int>로 변환하는 작업을 수행
       voteItemIds: (json['voteItemIds'] as List<dynamic>?)
           ?.map((item) => item as int)
+          .toList(),
+
+      // voteItems를 Map<String, dynamic>으로 변환
+      voteItems: (json['voteItems'] as List<dynamic>?)
+          ?.map((item) => item as Map<String, dynamic>)
           .toList(),
     );
   }
@@ -53,17 +56,7 @@ class Vote {
       'repetition': repetition,
       'additional': additional,
       'announcementId': announcementId,
-      'endTime': endTime,
-
-      // voteItemIds가 null이 아닐 때만 voteItemIds 필드를 JSON에 포함
-      // voteItemIds 리스트의 각 항목을 정수(int)로 변환하여 JSON 리스트로 생성
-      if (voteItemIds != null)
-        'voteItemIds': voteItemIds!.map((item) => item.toInt()).toList(),
+      'endDateTime': endDateTime,
     };
-  }
-
-  @override
-  String toString() {
-    return '{id: $id, subjectTitle: $subjectTitle, repetition: $repetition, additional: $additional, announcementId: $announcementId, endTime: $endTime, voteItemIds: $voteItemIds}';
   }
 }

--- a/frontend/lib/providers/vote_provider.dart
+++ b/frontend/lib/providers/vote_provider.dart
@@ -143,10 +143,33 @@ class VoteProvider with ChangeNotifier {
       },
     );
 
-    if (response.statusCode == 200) {
+    if (response.statusCode == 204) {
       print('투표 성공: ${response.body}');
     } else {
       print('투표 실패: ${response.statusCode} - ${response.body}');
+    }
+  }
+
+  // 투표 종료
+  Future<void> endVote(int voteId) async {
+    final accessToken = await getToken();
+    if (accessToken == null) {
+      throw Exception('엑세스 토큰을 찾을 수 없음');
+    }
+
+    final url = Uri.parse('$baseUrl$voteId/end');
+    final response = await http.post(
+      url,
+      headers: {
+        'access': accessToken,
+      },
+    );
+
+    if (response.statusCode == 200 || response.statusCode == 204) {
+      // 응답이 비어있을 경우 decode 작업을 수행하면 오류가 발생
+      print('투표 종료 성공: ${response.bodyBytes}');
+    } else {
+      print('투표 종료 실패: ${response.bodyBytes}');
     }
   }
 }

--- a/frontend/lib/providers/vote_provider.dart
+++ b/frontend/lib/providers/vote_provider.dart
@@ -1,5 +1,4 @@
 import 'dart:convert';
-
 import 'package:flutter/material.dart';
 import 'package:frontend/models/vote_model.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -22,14 +21,13 @@ class VoteProvider with ChangeNotifier {
   // final String baseUrl = 'http://127.0.0.1:9000/api/v1/votes/';
 
   // 투표 생성
-  Future<void> createVote(Vote vote) async {
+  Future<void> createVote(Vote vote, int announcementId) async {
     try {
       final accessToken = await getToken();
       if (accessToken == null) {
         throw Exception('엑세스 토큰을 찾을 수 없음');
       }
-
-      final url = Uri.parse(baseUrl);
+      final url = Uri.parse('$baseUrl$announcementId');
       final response = await http.post(
         url,
         headers: {
@@ -38,7 +36,6 @@ class VoteProvider with ChangeNotifier {
         },
         body: jsonEncode(vote.toJson()),
       );
-
       print('Response status: ${response.statusCode}');
       print('Response body: ${response.body}');
 
@@ -62,7 +59,6 @@ class VoteProvider with ChangeNotifier {
     if (accessToken == null) {
       throw Exception('엑세스 토큰을 찾을 수 없음');
     }
-
     final url = Uri.parse('$baseUrl$voteId/items');
     final response = await http.post(
       url,
@@ -72,19 +68,13 @@ class VoteProvider with ChangeNotifier {
       },
       body: jsonEncode({'content': content}), // JSON 형식으로 데이터를 전달
     );
-
     final utf8Response = utf8.decode(response.bodyBytes);
-
     if (response.statusCode == 201) {
       final jsonResponse = json.decode(utf8Response);
       final dataResponse = jsonResponse['data'];
 
-      _contentList.add(dataResponse);
-      notifyListeners();
-
       // 투표 항목 추가 후 해당 투표 항목을 다시 조회하여 UI 갱신
       await fetchVote(voteId);
-      print('투표 항목 추가 성공: $_contentList');
     } else {
       print('투표 항목 추가 실패: ${response.statusCode} - $utf8Response');
     }
@@ -96,7 +86,6 @@ class VoteProvider with ChangeNotifier {
     if (accessToken == null) {
       throw Exception('엑세스 토큰을 찾을 수 없음');
     }
-
     final url = Uri.parse('$baseUrl$voteId');
     final response = await http.get(
       url,
@@ -104,7 +93,6 @@ class VoteProvider with ChangeNotifier {
         'access': accessToken,
       },
     );
-
     _voteList.clear();
 
     if (response.statusCode == 200) {
@@ -113,28 +101,23 @@ class VoteProvider with ChangeNotifier {
 
       final dataResponse = jsonResponse['data'];
 
-      if (dataResponse is List) {
-        // dataResponse가 List일 경우 각각의 item을 Vote 객체로 변환
-        for (var data in dataResponse) {
-          _voteList.add(Vote.fromJson(data));
-        }
-      } else if (dataResponse is Map<String, dynamic>) {
-        // dataResponse가 Map일 경우 직접 Vote 객체로 변환하여 추가
-        _voteList.add(Vote.fromJson(dataResponse));
-      }
-      print('투표 조회 성공: $_voteList');
+      // dataResponse가 Map일 경우 직접 Vote 객체로 변환하여 추가
+      _voteList.add(Vote.fromJson(dataResponse));
+
+      notifyListeners();
+
+      print('투표 조회 성공: ${Vote.fromJson(dataResponse)} - $dataResponse');
     } else {
       print("투표 조회 실패: ${response.body}");
     }
   }
 
-  // 투표하기
+// 투표 하기
   Future<void> vote(int voteId, int voteItemId) async {
     final accessToken = await getToken();
     if (accessToken == null) {
       throw Exception('엑세스 토큰을 찾을 수 없음');
     }
-
     final url = Uri.parse('$baseUrl$voteId/vote/$voteItemId');
     final response = await http.post(
       url,
@@ -142,11 +125,33 @@ class VoteProvider with ChangeNotifier {
         'access': accessToken,
       },
     );
-
-    if (response.statusCode == 204) {
+    if (response.statusCode == 200) {
       print('투표 성공: ${response.body}');
     } else {
       print('투표 실패: ${response.statusCode} - ${response.body}');
+    }
+  }
+
+  // 투표 항목 강제 삭제
+  Future<void> deleteVoteItem(int voteId, int voteItemId) async {
+    final accessToken = await getToken();
+    if (accessToken == null) {
+      throw Exception('엑세스 토큰을 찾을 수 없음');
+    }
+    final url = Uri.parse('${baseUrl}items/$voteItemId');
+    final response = await http.delete(
+      url,
+      headers: {
+        'access': accessToken,
+      },
+    );
+    if (response.statusCode == 204) {
+      // 응답데이터 수정되면 작성 예정
+
+      await fetchVote(voteId);
+      print('투표 항목 강제 삭제 성공');
+    } else {
+      print('투표 항목 강제 삭제 실패');
     }
   }
 
@@ -165,9 +170,10 @@ class VoteProvider with ChangeNotifier {
       },
     );
 
-    if (response.statusCode == 200 || response.statusCode == 204) {
-      // 응답이 비어있을 경우 decode 작업을 수행하면 오류가 발생
-      print('투표 종료 성공: ${response.bodyBytes}');
+    if (response.statusCode == 200) {
+      // 종료 성공 시 투표 조회 호출
+      await fetchVote(voteId);
+      print('투표 종료 성공');
     } else {
       print('투표 종료 실패: ${response.bodyBytes}');
     }

--- a/frontend/lib/screens/write_screen.dart
+++ b/frontend/lib/screens/write_screen.dart
@@ -138,7 +138,7 @@ class _BoardWritePageState extends State<BoardWritePage> {
 
   // 시간 포맷팅 함수
   String formatDateTime(DateTime dateTime) {
-    final DateFormat formatter = DateFormat('yyyy-MM-ddTHH:mm:ss');
+    final DateFormat formatter = DateFormat('yyyy-MM-dd HH:mm:ss');
     return formatter.format(dateTime);
   }
 
@@ -452,11 +452,11 @@ class _BoardWritePageState extends State<BoardWritePage> {
                 repetition: isMultiplied,
                 additional: true,
                 announcementId: boardId,
-                endTime: formatDateTime(selectedEndDate!),
+                endDateTime: formatDateTime(selectedEndDate!),
                 // voteItemIds: [],
               );
 
-              await VoteProvider().createVote(vote);
+              await VoteProvider().createVote(vote, boardId);
             }
 
             // 알림 API

--- a/frontend/lib/widgets/vote_widget.dart
+++ b/frontend/lib/widgets/vote_widget.dart
@@ -187,19 +187,38 @@ class _VoteWidgetState extends State<VoteWidget> {
                     Row(
                       mainAxisAlignment: MainAxisAlignment.spaceBetween,
                       children: [
-                        Text(
-                          vote.subjectTitle ?? 'No Title',
-                          style: const TextStyle(
-                            fontSize: 16,
-                            fontWeight: FontWeight.bold,
+                        Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              vote.subjectTitle ?? 'No Title',
+                              style: const TextStyle(
+                                fontSize: 16,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                            Text(
+                              vote.endTime != null && vote.endTime!.isNotEmpty
+                                  ? DateFormat("d일 H시 mm분까지")
+                                      .format(DateTime.parse(vote.endTime!))
+                                  : 'No End Time',
+                              style: const TextStyle(
+                                color: Color(0xFF7D7D7F),
+                                fontSize: 12,
+                              ),
+                            ),
+                          ],
+                        ),
+
+                        // 투표 종료 버튼
+                        if (userRole == 'ROLE_ADMIN')
+                          TextButton(
+                            onPressed: () async {
+                              // 투표 종료 API 메서드 호출
+                              await VoteProvider().endVote(vote.id!);
+                            },
+                            child: const Text('종료'),
                           ),
-                        ),
-                        Text(
-                          vote.endTime != null && vote.endTime!.isNotEmpty
-                              ? DateFormat("d일 H시 mm분까지")
-                                  .format(DateTime.parse(vote.endTime!))
-                              : 'No End Time',
-                        ),
                       ],
                     ),
                     const SizedBox(height: 17),


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
#149

## ✨ 코드 변경 내용
<!-- 코드 변경에 대한 설명을 적어주세요 -->
### 투표 종료 API 메서드 작성 완료
- 엑세스 토큰 받은 후 헤더에 작성 및 응답이 비어있기 때문에 200이거나 204일 경우 투표 종료 성공이 콘솔에 출력되게 작성
- 종료시간을 투표 바로 옆에 놓고 종료 버튼을 우측 상단에 배치하는데 어드민만 볼 수 있도록 작성
### 투표 종료일 경우 UI 구현
- 투표 모델에 voteEnded 추가 및 endDateTime로 이름 수정
- 투표 종료 API 메서드에 투표 종료 성공 시 투표 조회 호출 코드 추가
- 투표 종료일 경우 더보기 버튼과 항목 추가 버튼이 안보이게, 투표 버튼에서 투표 종료 버튼으로 설정

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->
![Screenshot_1723975956](https://github.com/user-attachments/assets/bd561e8b-ef39-42d3-9119-9581c7f604f1)

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
