### PR TITLE
[Feat/#150] 투표 관련 API 연동

### DIFF
--- a/frontend/lib/models/vote_model.dart
+++ b/frontend/lib/models/vote_model.dart
@@ -4,8 +4,9 @@ class Vote {
   bool? repetition;
   bool? additional;
   int? announcementId;
-  String? endTime;
+  String? endDateTime;
   List<int>? voteItemIds;
+  List<Map<String, dynamic>>? voteItems;
 
   Vote({
     this.id,
@@ -13,8 +14,9 @@ class Vote {
     required this.repetition,
     required this.additional,
     required this.announcementId,
-    required this.endTime,
+    required this.endDateTime,
     this.voteItemIds,
+    this.voteItems,
   });
 
   // 데이터를 가져올 때 사용
@@ -25,23 +27,14 @@ class Vote {
       repetition: json['repetition'],
       additional: json['additional'],
       announcementId: json['announcementId'],
-
-      // endTime이 List<int> 형식으로 전달되는 경우, 이를 DateTime으로 변환 후 String으로 변환
-      endTime: json['endTime']
-              is List<dynamic> // json['endTime']이 List<dynamic> 타입인지 확인
-          ? DateTime(
-              json['endTime'][0],
-              json['endTime'][1],
-              json['endTime'][2],
-              json['endTime'][3],
-              json['endTime'][4],
-            ).toIso8601String() // List<int>로 변환하고 DateTime 객체로 변환
-          : json['endTime'] as String?, // DateTime 객체를 ISO 8601 형식의 String으로 변환
-
-      // 전달받은 json 맵에서 각 필드를 추출하여 Vote 객체 생성
-      // voteItemIds는 List<dynamic> 형식으로 전달될 수 있기 때문에, 이를 List<int>로 변환하는 작업을 수행
+      endDateTime: json['endDateTime'] as String?,
       voteItemIds: (json['voteItemIds'] as List<dynamic>?)
           ?.map((item) => item as int)
+          .toList(),
+
+      // voteItems를 Map<String, dynamic>으로 변환
+      voteItems: (json['voteItems'] as List<dynamic>?)
+          ?.map((item) => item as Map<String, dynamic>)
           .toList(),
     );
   }
@@ -53,17 +46,19 @@ class Vote {
       'repetition': repetition,
       'additional': additional,
       'announcementId': announcementId,
-      'endTime': endTime,
+      'endDateTime': endDateTime,
 
       // voteItemIds가 null이 아닐 때만 voteItemIds 필드를 JSON에 포함
       // voteItemIds 리스트의 각 항목을 정수(int)로 변환하여 JSON 리스트로 생성
       if (voteItemIds != null)
         'voteItemIds': voteItemIds!.map((item) => item.toInt()).toList(),
+
+      if (voteItems != null) 'voteItems': voteItems,
     };
   }
 
   @override
   String toString() {
-    return '{id: $id, subjectTitle: $subjectTitle, repetition: $repetition, additional: $additional, announcementId: $announcementId, endTime: $endTime, voteItemIds: $voteItemIds}';
+    return '{id: $id, subjectTitle: $subjectTitle, repetition: $repetition, additional: $additional, announcementId: $announcementId, endDateTime: $endDateTime, voteItemIds: $voteItemIds}';
   }
 }

--- a/frontend/lib/models/vote_model.dart
+++ b/frontend/lib/models/vote_model.dart
@@ -5,6 +5,8 @@ class Vote {
   bool? additional;
   int? announcementId;
   String? endDateTime;
+  bool? voteEnded;
+  bool? hasVoted;
   List<int>? voteItemIds;
   List<Map<String, dynamic>>? voteItems;
 
@@ -15,6 +17,8 @@ class Vote {
     required this.additional,
     required this.announcementId,
     required this.endDateTime,
+    this.voteEnded,
+    this.hasVoted,
     this.voteItemIds,
     this.voteItems,
   });
@@ -27,7 +31,17 @@ class Vote {
       repetition: json['repetition'],
       additional: json['additional'],
       announcementId: json['announcementId'],
-      endDateTime: json['endDateTime'] as String?,
+
+      // endTime이 List<int> 형식으로 전달되는 경우, 이를 DateTime으로 변환 후 String으로 변환
+      endDateTime: json['endDateTime']
+          as String?, // DateTime 객체를 ISO 8601 형식의 String으로 변환
+
+      voteEnded: json['voteEnded'],
+
+      hasVoted: json['hasVoted'],
+
+      // 전달받은 json 맵에서 각 필드를 추출하여 Vote 객체 생성
+      // voteItemIds는 List<dynamic> 형식으로 전달될 수 있기 때문에, 이를 List<int>로 변환하는 작업을 수행
       voteItemIds: (json['voteItemIds'] as List<dynamic>?)
           ?.map((item) => item as int)
           .toList(),
@@ -47,18 +61,6 @@ class Vote {
       'additional': additional,
       'announcementId': announcementId,
       'endDateTime': endDateTime,
-
-      // voteItemIds가 null이 아닐 때만 voteItemIds 필드를 JSON에 포함
-      // voteItemIds 리스트의 각 항목을 정수(int)로 변환하여 JSON 리스트로 생성
-      if (voteItemIds != null)
-        'voteItemIds': voteItemIds!.map((item) => item.toInt()).toList(),
-
-      if (voteItems != null) 'voteItems': voteItems,
     };
-  }
-
-  @override
-  String toString() {
-    return '{id: $id, subjectTitle: $subjectTitle, repetition: $repetition, additional: $additional, announcementId: $announcementId, endDateTime: $endDateTime, voteItemIds: $voteItemIds}';
   }
 }

--- a/frontend/lib/providers/vote_provider.dart
+++ b/frontend/lib/providers/vote_provider.dart
@@ -122,22 +122,27 @@ class VoteProvider with ChangeNotifier {
   }
 
   // 투표 하기
-  Future<void> vote(int voteId, int voteItemId) async {
+  Future<void> vote(int voteId, List<int> voteItemIds) async {
     final accessToken = await getToken();
     if (accessToken == null) {
       throw Exception('엑세스 토큰을 찾을 수 없음');
     }
 
-    final url = Uri.parse('$baseUrl$voteId/vote/$voteItemId');
+    final url = Uri.parse('$baseUrl$voteId/vote');
     final response = await http.post(
       url,
       headers: {
         'access': accessToken,
+        'Content-Type': 'application/json',
       },
+      body: jsonEncode({"voteItemIds": voteItemIds}), // 리스트를 JSON 문자열로 변환
     );
 
     if (response.statusCode == 200) {
-      print('투표 성공: ${response.body}');
+      final utf8Response = utf8.decode(response.bodyBytes);
+      final jsonResponse = json.decode(utf8Response);
+
+      print('투표 성공: ${jsonResponse['data']}');
     } else {
       print('투표 실패: ${response.statusCode} - ${response.body}');
     }
@@ -159,9 +164,6 @@ class VoteProvider with ChangeNotifier {
     );
 
     if (response.statusCode == 204) {
-      // 응답데이터 수정되면 작성 예정
-
-      await fetchVote(voteId);
       print('투표 항목 강제 삭제 성공');
     } else {
       print('투표 항목 강제 삭제 실패');

--- a/frontend/lib/providers/vote_provider.dart
+++ b/frontend/lib/providers/vote_provider.dart
@@ -79,8 +79,6 @@ class VoteProvider with ChangeNotifier {
       final jsonResponse = json.decode(utf8Response);
       final dataResponse = jsonResponse['data'];
 
-      // 투표 항목 추가 후 해당 투표 항목을 다시 조회하여 UI 갱신
-      await fetchVote(voteId);
       print('투표 항목 추가 성공: $dataResponse');
     } else {
       print('투표 항목 추가 실패: ${response.statusCode} - $utf8Response');

--- a/frontend/lib/providers/vote_provider.dart
+++ b/frontend/lib/providers/vote_provider.dart
@@ -119,6 +119,30 @@ class VoteProvider with ChangeNotifier {
     }
   }
 
+  // 투표 삭제
+  Future<void> deleteVote(int voteId) async {
+    final accessToken = await getToken();
+    if (accessToken == null) {
+      throw Exception('엑세스 토큰을 찾을 수 없음');
+    }
+
+    final url = Uri.parse('$baseUrl/$voteId');
+    final response = await http.delete(
+      url,
+      headers: {'access': accessToken},
+    );
+
+    if (response.statusCode == 200) {
+      final utf8Response = utf8.decode(response.bodyBytes);
+      final jsonResponse = json.decode(utf8Response);
+
+      final dataResponse = jsonResponse['data'];
+      print('투표 삭제 성공: $dataResponse');
+    } else {
+      print('투표 삭제 실패: ${response.body}');
+    }
+  }
+
   // 투표 하기
   Future<void> vote(int voteId, List<int> voteItemIds) async {
     final accessToken = await getToken();
@@ -159,7 +183,7 @@ class VoteProvider with ChangeNotifier {
       headers: {'access': accessToken},
     );
 
-    if (response.statusCode == 204) {
+    if (response.statusCode == 200) {
       print('투표 항목 강제 삭제 성공');
     } else {
       print('투표 항목 강제 삭제 실패');

--- a/frontend/lib/providers/vote_provider.dart
+++ b/frontend/lib/providers/vote_provider.dart
@@ -149,4 +149,28 @@ class VoteProvider with ChangeNotifier {
       print('투표 실패: ${response.statusCode} - ${response.body}');
     }
   }
+
+  // 투표 항목 강제 삭제
+  Future<void> deleteVoteItem(int voteItemId) async {
+    final accessToken = await getToken();
+    if (accessToken == null) {
+      throw Exception('엑세스 토큰을 찾을 수 없음');
+    }
+
+    final url = Uri.parse('${baseUrl}items/$voteItemId');
+    final response = await http.delete(
+      url,
+      headers: {
+        'access': accessToken,
+      },
+    );
+
+    if (response.statusCode == 204) {
+      // 응답데이터 수정되면 작성 예정
+
+      print('투표 항목 강제 삭제 성공');
+    } else {
+      print('투표 항목 강제 삭제 실패');
+    }
+  }
 }

--- a/frontend/lib/providers/vote_provider.dart
+++ b/frontend/lib/providers/vote_provider.dart
@@ -18,8 +18,8 @@ class VoteProvider with ChangeNotifier {
     return prefs.getString('accessToken'); // accessToken 키로 저장된 문자열 값을 가져옴
   }
 
-  final String baseUrl = 'http://10.0.2.2:9000/api/v1/votes/';
-  // final String baseUrl = 'http://127.0.0.1:9000/api/v1/votes/';
+  final String baseUrl = 'http://10.0.2.2:9000/api/v1/votes';
+  // final String baseUrl = 'http://127.0.0.1:9000/api/v1/votes';
 
   // 투표 생성
   Future<void> createVote(Vote vote, int announcementId) async {
@@ -29,7 +29,7 @@ class VoteProvider with ChangeNotifier {
         throw Exception('엑세스 토큰을 찾을 수 없음');
       }
 
-      final url = Uri.parse('$baseUrl$announcementId');
+      final url = Uri.parse('$baseUrl/$announcementId');
       final response = await http.post(
         url,
         headers: {
@@ -63,7 +63,7 @@ class VoteProvider with ChangeNotifier {
       throw Exception('엑세스 토큰을 찾을 수 없음');
     }
 
-    final url = Uri.parse('$baseUrl$voteId/items');
+    final url = Uri.parse('$baseUrl/$voteId/items');
     final response = await http.post(
       url,
       headers: {
@@ -92,7 +92,7 @@ class VoteProvider with ChangeNotifier {
       throw Exception('엑세스 토큰을 찾을 수 없음');
     }
 
-    final url = Uri.parse('$baseUrl$voteId');
+    final url = Uri.parse('$baseUrl/$voteId');
     final response = await http.get(
       url,
       headers: {
@@ -126,7 +126,7 @@ class VoteProvider with ChangeNotifier {
       throw Exception('엑세스 토큰을 찾을 수 없음');
     }
 
-    final url = Uri.parse('$baseUrl$voteId/vote');
+    final url = Uri.parse('$baseUrl/$voteId/vote');
     final response = await http.post(
       url,
       headers: {
@@ -153,18 +153,40 @@ class VoteProvider with ChangeNotifier {
       throw Exception('엑세스 토큰을 찾을 수 없음');
     }
 
-    final url = Uri.parse('${baseUrl}items/$voteItemId');
+    final url = Uri.parse('$baseUrl/items/$voteItemId');
     final response = await http.delete(
       url,
-      headers: {
-        'access': accessToken,
-      },
+      headers: {'access': accessToken},
     );
 
     if (response.statusCode == 204) {
       print('투표 항목 강제 삭제 성공');
     } else {
       print('투표 항목 강제 삭제 실패');
+    }
+  }
+
+  // 투표 재투표
+  Future<void> recastVote(int voteId, List<int> voteItemIds) async {
+    final accessToken = await getToken();
+    if (accessToken == null) {
+      throw Exception('엑세스 토큰을 찾을 수 없음');
+    }
+
+    final url = Uri.parse('$baseUrl/$voteId/recast');
+    final response = await http.post(
+      url,
+      headers: {
+        'access': accessToken,
+        'Content-Type': 'application/json',
+      },
+      body: jsonEncode(voteItemIds),
+    );
+
+    if (response.statusCode == 200) {
+      print('투표 재투표 성공: ${response.body}');
+    } else {
+      print('투표 재투표 실패: ${response.body}');
     }
   }
 }

--- a/frontend/lib/screens/boardDetail_screen.dart
+++ b/frontend/lib/screens/boardDetail_screen.dart
@@ -3,6 +3,8 @@ import 'package:frontend/all/providers/announcement_provider.dart';
 import 'package:frontend/models/vote_model.dart';
 import 'package:frontend/providers/recommend_provider.dart';
 import 'package:frontend/providers/vote_provider.dart';
+import 'package:frontend/screens/myOwnerPage_screen.dart';
+import 'package:frontend/screens/myUserPage_screen.dart';
 import 'package:frontend/widgets/vote_widget.dart';
 import 'package:frontend/services/login_services.dart';
 import 'package:provider/provider.dart';
@@ -89,8 +91,8 @@ class _BoardDetailPageState extends State<BoardDetailPage> {
           ),
         ),
         leadingWidth: 120,
-        actions: const [
-          Padding(
+        actions: [
+          const Padding(
             padding: EdgeInsets.only(right: 20.0),
             child: Icon(
               Icons.add_alert,
@@ -99,11 +101,23 @@ class _BoardDetailPageState extends State<BoardDetailPage> {
             ),
           ),
           Padding(
-            padding: EdgeInsets.only(right: 20.0),
-            child: Icon(
-              Icons.account_circle,
-              size: 30,
-              color: Colors.black,
+            padding: const EdgeInsets.only(right: 20.0),
+            child: IconButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (context) => (userRole == 'ROLE_ADMIN')
+                        ? const MyOwnerPage()
+                        : const MyUserPage(),
+                  ),
+                );
+              },
+              icon: const Icon(
+                Icons.account_circle,
+                size: 30,
+                color: Colors.black,
+              ),
             ),
           ),
         ],
@@ -150,17 +164,17 @@ class _BoardDetailPageState extends State<BoardDetailPage> {
                 ),
               ),
               const SizedBox(height: 15),
-              ClipRRect(
-                borderRadius: BorderRadius.circular(10.0),
-                child: SizedBox(
-                  width: 341,
-                  height: 296,
-                  child: Image.asset(
-                    'assets/images/classselect.png',
-                    fit: BoxFit.cover,
-                  ),
-                ),
-              ),
+              // ClipRRect(
+              //   borderRadius: BorderRadius.circular(10.0),
+              //   child: SizedBox(
+              //     width: 341,
+              //     height: 296,
+              //     child: Image.asset(
+              //       'assets/images/classselect.png',
+              //       fit: BoxFit.cover,
+              //     ),
+              //   ),
+              // ),
               const SizedBox(height: 15),
               Row(
                 crossAxisAlignment: CrossAxisAlignment.center,

--- a/frontend/lib/screens/totalBoard_screen.dart
+++ b/frontend/lib/screens/totalBoard_screen.dart
@@ -117,75 +117,82 @@ class _TotalBoardPageState extends State<TotalBoardPage> {
           ? Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
-                ElevatedButton(
-                  onPressed: () async {
-                    if (selectedBoard != null) {
-                      print('id: ${selectedBoard!['id']}');
-                      await Provider.of<AnnouncementProvider>(context,
-                              listen: false)
-                          .hiddenBoard(selectedBoard!, selectedBoard!['id']);
-
-                      // 전체 boardList를 다시 불러옴
-                      if (context.mounted) {
+                SizedBox(
+                  width: MediaQuery.of(context).size.width / 2,
+                  height: MediaQuery.of(context).size.height / 12,
+                  child: ElevatedButton(
+                    onPressed: () async {
+                      if (selectedBoard != null) {
+                        print('id: ${selectedBoard!['id']}');
                         await Provider.of<AnnouncementProvider>(context,
                                 listen: false)
-                            .fetchAllBoards();
+                            .hiddenBoard(selectedBoard!, selectedBoard!['id']);
+
+                        // 전체 boardList를 다시 불러옴
+                        if (context.mounted) {
+                          await Provider.of<AnnouncementProvider>(context,
+                                  listen: false)
+                              .fetchAllBoards();
+                        }
+                        setState(() {
+                          isHidDel = false; // 숨김/삭제 버튼 숨기기
+                          selectedBoard = null; // 선택된 게시글 초기화
+                        });
                       }
-                      setState(() {
-                        isHidDel = false; // 숨김/삭제 버튼 숨기기
-                        selectedBoard = null; // 선택된 게시글 초기화
-                      });
-                    }
-                  },
-                  style: ElevatedButton.styleFrom(
-                    backgroundColor: const Color(0xFFFAFAFE),
-                    minimumSize: const Size(205, 75),
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(0),
+                    },
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: const Color(0xFFFAFAFE),
+                      minimumSize: const Size(205, 75),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(0),
+                      ),
                     ),
-                  ),
-                  child: const Text(
-                    '숨김',
-                    style: TextStyle(
-                      color: Color(0xFF7D7D7F),
-                      fontSize: 20,
-                      fontWeight: FontWeight.bold,
+                    child: const Text(
+                      '숨김',
+                      style: TextStyle(
+                        color: Color(0xFF7D7D7F),
+                        fontSize: 20,
+                        fontWeight: FontWeight.bold,
+                      ),
                     ),
                   ),
                 ),
-                ElevatedButton(
-                  onPressed: () async {
-                    if (selectedBoard != null) {
-                      print('id: ${selectedBoard!['id']}');
-                      await Provider.of<AnnouncementProvider>(context,
-                              listen: false)
-                          .deletedBoard(selectedBoard!['id']);
-
-                      // 전체 boardList를 다시 불러옴
-                      if (context.mounted) {
+                SizedBox(
+                  width: MediaQuery.of(context).size.width / 2,
+                  height: MediaQuery.of(context).size.height / 12,
+                  child: ElevatedButton(
+                    onPressed: () async {
+                      if (selectedBoard != null) {
+                        print('id: ${selectedBoard!['id']}');
                         await Provider.of<AnnouncementProvider>(context,
                                 listen: false)
-                            .fetchAllBoards();
+                            .deletedBoard(selectedBoard!['id']);
+
+                        // 전체 boardList를 다시 불러옴
+                        if (context.mounted) {
+                          await Provider.of<AnnouncementProvider>(context,
+                                  listen: false)
+                              .fetchAllBoards();
+                        }
+                        setState(() {
+                          isHidDel = false; // 숨김/삭제 버튼 숨기기
+                          selectedBoard = null; // 선택된 게시글 초기화
+                        });
                       }
-                      setState(() {
-                        isHidDel = false; // 숨김/삭제 버튼 숨기기
-                        selectedBoard = null; // 선택된 게시글 초기화
-                      });
-                    }
-                  },
-                  style: ElevatedButton.styleFrom(
-                    backgroundColor: const Color(0xFFFAFAFE),
-                    minimumSize: const Size(205, 75),
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(0),
+                    },
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: const Color(0xFFFAFAFE),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(0),
+                      ),
                     ),
-                  ),
-                  child: const Text(
-                    '삭제',
-                    style: TextStyle(
-                      color: Color(0xFF7D7D7F),
-                      fontSize: 20,
-                      fontWeight: FontWeight.bold,
+                    child: const Text(
+                      '삭제',
+                      style: TextStyle(
+                        color: Color(0xFF7D7D7F),
+                        fontSize: 20,
+                        fontWeight: FontWeight.bold,
+                      ),
                     ),
                   ),
                 ),

--- a/frontend/lib/screens/write_screen.dart
+++ b/frontend/lib/screens/write_screen.dart
@@ -138,7 +138,7 @@ class _BoardWritePageState extends State<BoardWritePage> {
 
   // 시간 포맷팅 함수
   String formatDateTime(DateTime dateTime) {
-    final DateFormat formatter = DateFormat('yyyy-MM-ddTHH:mm:ss');
+    final DateFormat formatter = DateFormat('yyyy-MM-dd HH:mm:ss');
     return formatter.format(dateTime);
   }
 
@@ -452,30 +452,30 @@ class _BoardWritePageState extends State<BoardWritePage> {
                 repetition: isMultiplied,
                 additional: true,
                 announcementId: boardId,
-                endTime: formatDateTime(selectedEndDate!),
+                endDateTime: formatDateTime(selectedEndDate!),
                 // voteItemIds: [],
               );
 
-              await VoteProvider().createVote(vote);
+              await VoteProvider().createVote(vote, boardId);
             }
 
             // 알림 API
-            String fcmToken = await _getFCMToken(); // fcm토큰 할당
-            DateTime dt = DateTime.now(); // 현재시간 할당
+            // String fcmToken = await _getFCMToken(); // fcm토큰 할당
+            // DateTime dt = DateTime.now(); // 현재시간 할당
 
-            // 날짜 시간을 문자열로 변환 후 '.'기준으로 분할해 0번째(첫 번째)부분 선택
-            // 공백(' ')을 T로 대체
-            String createdAt = dt.toString().split('.')[0].replaceAll(' ', 'T');
+            // // 날짜 시간을 문자열로 변환 후 '.'기준으로 분할해 0번째(첫 번째)부분 선택
+            // // 공백(' ')을 T로 대체
+            // String createdAt = dt.toString().split('.')[0].replaceAll(' ', 'T');
 
-            Map<String, dynamic> notificationData = {
-              "title": titleController.text,
-              "content": contentController.text,
-              "category": getSelectedCategoryText(),
-              "targetId": boardId, // 게시글 아이디
-              "createdAt": createdAt, // 생성일
-            };
-            await NotificationService()
-                .notification(notificationData, fcmToken);
+            // Map<String, dynamic> notificationData = {
+            //   "title": titleController.text,
+            //   "content": contentController.text,
+            //   "category": getSelectedCategoryText(),
+            //   "targetId": boardId, // 게시글 아이디
+            //   "createdAt": createdAt, // 생성일
+            // };
+            // await NotificationService()
+            //     .notification(notificationData, fcmToken);
 
             if (context.mounted) {
               Navigator.popAndPushNamed(context, '/total-board');

--- a/frontend/lib/widgets/vote_widget.dart
+++ b/frontend/lib/widgets/vote_widget.dart
@@ -134,16 +134,20 @@ class _VoteWidgetState extends State<VoteWidget> {
             .fetchVote(vote.id!);
 
         // 투표 정보 가져온 후, 해당 투표의 항목 개수에 맞게 리스트 초기화
-        setState(() {
-          _showIconList =
-              List<bool>.from(List.filled(vote.voteItemIds!.length, false));
-          _circleColors = List<Color>.from(
-              List.filled(vote.voteItemIds!.length, Colors.black));
-          _hasVotedList =
-              List<bool>.from(List.filled(vote.voteItemIds!.length, false));
-          _voteCounts =
-              List<int>.from(List.filled(vote.voteItemIds!.length, 0));
-        });
+        if (mounted) {
+          // mounted: setState가 호출되는 시점에 위젯이 이미 화면에 존재하지 않아 발생하는 예외를 방지하기 위해
+          // mounted를 통해 확인
+          setState(() {
+            _showIconList =
+                List<bool>.from(List.filled(vote.voteItemIds!.length, false));
+            _circleColors = List<Color>.from(
+                List.filled(vote.voteItemIds!.length, Colors.black));
+            _hasVotedList =
+                List<bool>.from(List.filled(vote.voteItemIds!.length, false));
+            _voteCounts =
+                List<int>.from(List.filled(vote.voteItemIds!.length, 0));
+          });
+        }
       }
     });
 
@@ -218,104 +222,149 @@ class _VoteWidgetState extends State<VoteWidget> {
                               contentList.isNotEmpty)
                             for (int i = 0; i < vote.voteItemIds!.length; i++)
                               if (i < contentList.length)
-                                InkWell(
-                                  // GestureDetector를 InkWell로 대체
-                                  onTap: () => _toggleIcon(
-                                      i,
-                                      vote.voteItemIds![i],
-                                      vote.repetition!), // 아이콘 토글 함수 호출
-                                  child: Card(
-                                    color: const Color(0xFFEFEFF2),
-                                    shape: RoundedRectangleBorder(
-                                      borderRadius: BorderRadius.circular(5.0),
-                                    ),
-                                    elevation: 0.5,
-                                    child: Container(
-                                      padding: const EdgeInsets.symmetric(
-                                          horizontal: 20.0, vertical: 6.0),
-                                      width: 171,
-                                      height: 28,
-                                      child: Row(
-                                        mainAxisAlignment:
-                                            MainAxisAlignment.start,
-                                        children: [
-                                          // 이미 투표를 완료한 경우 체크 아이콘 표시
-                                          if (i < _showIconList.length &&
-                                              _showIconList[i] &&
-                                              _hasVoted)
-                                            Image.asset(
-                                              'assets/images/votecheck.png',
-                                              width: 12,
-                                              height: 12,
-                                            )
-                                          // 투표 아이콘만 선택된 경우, 터치 가능한 원 모양 아이콘 표시
-                                          else if (i < _showIconList.length &&
-                                              _showIconList[i])
-                                            InkWell(
-                                              onTap: () => _toggleIcon(
-                                                  i,
-                                                  vote.voteItemIds![i],
-                                                  vote.repetition!),
-                                              borderRadius:
-                                                  BorderRadius.circular(10.0),
-                                              child: Container(
-                                                padding:
-                                                    const EdgeInsets.all(1.0),
-                                                decoration: BoxDecoration(
-                                                  color: _circleColors[i],
-                                                  shape: BoxShape.circle,
-                                                ),
-                                                child: CircleAvatar(
-                                                  radius: 10.0,
-                                                  backgroundColor: Colors.white,
-                                                  child: Icon(
-                                                    Icons.circle,
-                                                    size: 6.0,
-                                                    color: _circleColors[i],
+                                Row(
+                                  children: [
+                                    InkWell(
+                                      // GestureDetector를 InkWell로 대체
+                                      onTap: () => _toggleIcon(
+                                          i,
+                                          vote.voteItemIds![i],
+                                          vote.repetition!), // 아이콘 토글 함수 호출
+                                      child: Card(
+                                        color: const Color(0xFFEFEFF2),
+                                        shape: RoundedRectangleBorder(
+                                          borderRadius:
+                                              BorderRadius.circular(5.0),
+                                        ),
+                                        elevation: 0.5,
+                                        child: Container(
+                                          padding: const EdgeInsets.symmetric(
+                                              horizontal: 20.0, vertical: 6.0),
+                                          width: 171,
+                                          height: 28,
+                                          child: Row(
+                                            mainAxisAlignment:
+                                                MainAxisAlignment.start,
+                                            children: [
+                                              // 이미 투표를 완료한 경우 체크 아이콘 표시
+                                              if (i < _showIconList.length &&
+                                                  _showIconList[i] &&
+                                                  _hasVoted)
+                                                Image.asset(
+                                                  'assets/images/votecheck.png',
+                                                  width: 12,
+                                                  height: 12,
+                                                )
+                                              // 투표 아이콘만 선택된 경우, 터치 가능한 원 모양 아이콘 표시
+                                              else if (i <
+                                                      _showIconList.length &&
+                                                  _showIconList[i])
+                                                InkWell(
+                                                  onTap: () => _toggleIcon(
+                                                      i,
+                                                      vote.voteItemIds![i],
+                                                      vote.repetition!),
+                                                  borderRadius:
+                                                      BorderRadius.circular(
+                                                          10.0),
+                                                  child: Container(
+                                                    padding:
+                                                        const EdgeInsets.all(
+                                                            1.0),
+                                                    decoration: BoxDecoration(
+                                                      color: _circleColors[i],
+                                                      shape: BoxShape.circle,
+                                                    ),
+                                                    child: CircleAvatar(
+                                                      radius: 10.0,
+                                                      backgroundColor:
+                                                          Colors.white,
+                                                      child: Icon(
+                                                        Icons.circle,
+                                                        size: 6.0,
+                                                        color: _circleColors[i],
+                                                      ),
+                                                    ),
                                                   ),
                                                 ),
-                                              ),
-                                            ),
-                                          const SizedBox(width: 8.0),
-                                          // 투표 항목 내용 표시
-                                          Text(
-                                            contentList[i]['content'],
-                                            style: const TextStyle(
-                                              fontSize: 11,
-                                              fontWeight: FontWeight.bold,
-                                              color: Colors.black,
-                                            ),
-                                          ),
-                                          const SizedBox(width: 20),
-                                          // 투표 완료한 경우 투표 인원 표시
-                                          if (_hasVoted &&
-                                              i < _showIconList.length &&
-                                              _showIconList[i])
-                                            GestureDetector(
-                                              onTap: () {
-                                                Navigator.push(
-                                                  context,
-                                                  MaterialPageRoute(
-                                                    builder: (context) =>
-                                                        const ViewVotePage(),
-                                                  ),
-                                                );
-                                              },
-                                              child: Text(
-                                                '${_voteCounts[i]}명',
+                                              const SizedBox(width: 8.0),
+                                              // 투표 항목 내용 표시
+                                              Text(
+                                                contentList[i]['content'],
                                                 style: const TextStyle(
                                                   fontSize: 11,
                                                   fontWeight: FontWeight.bold,
                                                   color: Colors.black,
                                                 ),
                                               ),
-                                            ),
-                                        ],
+                                              const SizedBox(width: 20),
+                                              // 투표 완료한 경우 투표 인원 표시
+                                              if (_hasVoted &&
+                                                  i < _showIconList.length &&
+                                                  _showIconList[i])
+                                                GestureDetector(
+                                                  onTap: () {
+                                                    Navigator.push(
+                                                      context,
+                                                      MaterialPageRoute(
+                                                        builder: (context) =>
+                                                            const ViewVotePage(),
+                                                      ),
+                                                    );
+                                                  },
+                                                  child: Text(
+                                                    '${_voteCounts[i]}명',
+                                                    style: const TextStyle(
+                                                      fontSize: 11,
+                                                      fontWeight:
+                                                          FontWeight.bold,
+                                                      color: Colors.black,
+                                                    ),
+                                                  ),
+                                                ),
+                                            ],
+                                          ),
+                                        ),
                                       ),
                                     ),
-                                  ),
+
+                                    // 삭제 버튼(관리자만 보이게 설정)
+                                    if (userRole == 'ROLE_ADMIN')
+                                      IconButton(
+                                        onPressed: () async {
+                                          // 투표 항목 강제 삭제 API
+                                          await Provider.of<VoteProvider>(
+                                                  context,
+                                                  listen: false)
+                                              .deleteVoteItem(
+                                                  vote.voteItemIds![i]);
+
+                                          setState(() {
+                                            // 항목을 삭제하면서 상태 리스트에서도 제거
+                                            vote.voteItemIds!.removeAt(i);
+                                            _showIconList.removeAt(i);
+                                            _circleColors.removeAt(i);
+                                            _hasVotedList.removeAt(i);
+                                            _voteCounts.removeAt(i);
+                                          });
+
+                                          // 투표 조회 API
+                                          if (context.mounted) {
+                                            await Provider.of<VoteProvider>(
+                                                    context,
+                                                    listen: false)
+                                                .fetchVote(vote.id!);
+                                          }
+                                        },
+                                        icon: const Icon(
+                                          Icons.delete,
+                                          color: Color(0xFF2B72E7),
+                                        ),
+                                      ),
+                                  ],
                                 ),
                           const SizedBox(height: 4.0),
+
                           // 항목 추가 및 투표 인원 표시
                           Row(
                             mainAxisAlignment: MainAxisAlignment.spaceBetween,
@@ -384,6 +433,7 @@ class _VoteWidgetState extends State<VoteWidget> {
                               ),
                             ],
                           ),
+
                           // 새로 추가된 항목 입력 필드 생성
                           for (int i = 0; i < _isItemVisibleList.length; i++)
                             if (_isItemVisibleList[i])
@@ -434,7 +484,8 @@ class _VoteWidgetState extends State<VoteWidget> {
                                     ),
                                   ),
                                   const SizedBox(width: 8.0),
-                                  // 확인 버튼
+
+                                  // 확인 버튼(항목 추가)
                                   Expanded(
                                     flex: 2,
                                     child: GestureDetector(
@@ -442,6 +493,7 @@ class _VoteWidgetState extends State<VoteWidget> {
                                         final content =
                                             _itemInputControllers[i].text;
 
+                                        // 투표 항목 추가 API
                                         if (content.isNotEmpty) {
                                           await Provider.of<VoteProvider>(
                                                   context,
@@ -486,6 +538,7 @@ class _VoteWidgetState extends State<VoteWidget> {
                                     ),
                                   ),
                                   const SizedBox(width: 8.0),
+
                                   // 취소 버튼
                                   Expanded(
                                     flex: 2,
@@ -524,6 +577,7 @@ class _VoteWidgetState extends State<VoteWidget> {
                                 ],
                               ),
                           const SizedBox(height: 6.0),
+
                           // 투표하기 버튼
                           Center(
                             child: SizedBox(


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
#150

## ✨ 코드 변경 내용
<!-- 코드 변경에 대한 설명을 적어주세요 -->
### 투표하기 api 연동
- repetition에 따라 선택한 항목을 담는 변수타입을 다르게 설정
- 항목을 클릭했을 때 해당 아이디값을 추가하고 다시 클릭했을 때 해당 아이디값이 있으면 삭제
- hasVoted가 true이면 인원 수 표시와 재투표하기 버튼으로 변환
###  항목 추가 API 연동
- 항목 입력 칸 열고 닫기 여부와 항목 입력 컨트롤러 변수를 선언
- 컨트롤러가 비어있지 않을때 항목 추가, 조회 api 호출 후 항목 입력 칸을 닫기 위해 isOpened를 false로  설정
- 다른 내용을 작성하기 위해 컨트롤러 클리어
- 관리자 혹은 투표 완료일 경우 항목 추가 클릭 기능 상실
### 재투표 API 연동
- 재투표 여부를 선언해 재투표하기 버튼을 눌렀을 때 재투표 여부를 true로 변환해 재투표 API를 호출할 수 있도록 설정
- vote.hasVoted를 false로 변환해 선택 시 아이콘(원모양) 보이게 하고
- 투표 api 호출하는부분에서 재투표 api 호출 코드를 작성할 수 있도록 작성
- 나중에 다시 재투표할 수 있도록 설정
### 투표 및 투표 항목 삭제 api 연동
- 항목추가와 투표하기 버튼은 사용자만 볼 수 있게 구현
- 관리자는 해당 투표 항목 인원은 무조건 볼 수 있게 구현
- 투표 삭제할 때 경고 다이얼로그를 띄워 삭제하도록 설정 후 게시글 조회를 해 UI 바로 업데이트되게 구현

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
