### PR TITLE
[Feat/#167] recruitment 카테고리별 삭제

### DIFF
--- a/frontend/lib/admin/providers/admin_provider.dart
+++ b/frontend/lib/admin/providers/admin_provider.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:frontend/admin/models/admin_model.dart';
 import 'package:frontend/admin/services/userInfo_service.dart';
@@ -120,6 +122,26 @@ class AdminProvider with ChangeNotifier {
       print('모집글 전체 삭제 성공: ${response.body}');
     } else {
       print('모집글 전체 삭제 실패: ${response.body}');
+    }
+  }
+
+  // recruitment 카테고리 별 삭제
+  Future<void> deleteCateRecruitment(String contestCate) async {
+    final accessToken = await getToken();
+    if (accessToken == null) {
+      throw Exception('엑세스 토큰을 찾을 수 없음');
+    }
+
+    final url = Uri.parse('${baseUrl}recruitment-delete?category=$contestCate');
+    final response = await http.delete(
+      url,
+      headers: {'access': accessToken},
+    );
+
+    if (response.statusCode == 200) {
+      print('카테고리 별 삭제 성공: ${response.body}');
+    } else {
+      print('카테고리 별 삭제 실패: ${response.body}');
     }
   }
 }

--- a/frontend/lib/screens/memberRecruit_screen.dart
+++ b/frontend/lib/screens/memberRecruit_screen.dart
@@ -237,6 +237,7 @@ class _MemberRecruitPageState extends State<MemberRecruitPage> {
     return _buildPostContent(recruitList);
   }
 
+  // 선택한 카테고리 팝업 메뉴
   void selectCateMenu(BuildContext context) {
     // AnnouncementProvider에서 카테고리 리스트를 가져옴
     final categoryList =
@@ -261,14 +262,16 @@ class _MemberRecruitPageState extends State<MemberRecruitPage> {
     ).then((selectedItem) {
       // 사용자가 항목을 선택했고, 그 항목이 categoryList에 존재하는 경우
       if (selectedItem != null && categoryList.contains(selectedItem)) {
-        Navigator.push(
-          context,
-          MaterialPageRoute(
-            builder: (context) => MakeTeamPage(
-              initialCategory: selectedItem, // 선택된 항목을 초기 카테고리로 전달
+        if (userRole == 'ROLE_USER') {
+          Navigator.push(
+            context,
+            MaterialPageRoute(
+              builder: (context) => MakeTeamPage(
+                initialCategory: selectedItem, // 선택된 항목을 초기 카테고리로 전달
+              ),
             ),
-          ),
-        );
+          );
+        } else if (userRole == 'ROLE_ADMIN') {}
       }
     });
   }
@@ -375,7 +378,7 @@ class _MemberRecruitPageState extends State<MemberRecruitPage> {
                   PopupMenuButton<String>(
                     color: const Color(0xFFEFF0F2),
                     onSelected: (String item) async {
-                      if (item == '모집글 작성') {
+                      if (item == '모집글 작성' || item == '개별 삭제') {
                         selectCateMenu(context); // 새로운 팝업 메뉴 생성 `
                       }
                       if (item == '모집글 전체 삭제') {
@@ -389,6 +392,8 @@ class _MemberRecruitPageState extends State<MemberRecruitPage> {
                           popUpItem('URL 공유', 'URL 공유'),
                           const PopupMenuDivider(),
                           popUpItem('모집글 전체 삭제', '모집글 전체 삭제'),
+                          const PopupMenuDivider(),
+                          popUpItem('개별 삭제', '개별 삭제'),
                         ];
                       } else {
                         return <PopupMenuEntry<String>>[

--- a/frontend/lib/screens/memberRecruit_screen.dart
+++ b/frontend/lib/screens/memberRecruit_screen.dart
@@ -248,6 +248,7 @@ class _MemberRecruitPageState extends State<MemberRecruitPage> {
       context: context,
       // 메뉴가 화면에 나타나는 위치 RelativeRect
       position: const RelativeRect.fromLTRB(287, 200, 900, 500),
+      color: const Color(0xFFDFDEE5),
       // 팝업 메뉴에 들어갈 항목
       items: <PopupMenuEntry<String>>[
         for (int i = 0; i < categoryList.length; i++) ...[
@@ -259,7 +260,7 @@ class _MemberRecruitPageState extends State<MemberRecruitPage> {
         // categoryList가 비어있지 않은 경우, 마지막에 Divider를 추가
         if (categoryList.isNotEmpty) const PopupMenuDivider(),
       ],
-    ).then((selectedItem) {
+    ).then((selectedItem) async {
       // 사용자가 항목을 선택했고, 그 항목이 categoryList에 존재하는 경우
       if (selectedItem != null && categoryList.contains(selectedItem)) {
         if (userRole == 'ROLE_USER') {
@@ -271,7 +272,9 @@ class _MemberRecruitPageState extends State<MemberRecruitPage> {
               ),
             ),
           );
-        } else if (userRole == 'ROLE_ADMIN') {}
+        } else if (userRole == 'ROLE_ADMIN') {
+          deleteDialog(context, 'individual', selectedItem);
+        }
       }
     });
   }
@@ -382,7 +385,7 @@ class _MemberRecruitPageState extends State<MemberRecruitPage> {
                         selectCateMenu(context); // 새로운 팝업 메뉴 생성 `
                       }
                       if (item == '모집글 전체 삭제') {
-                        deleteDialog(context);
+                        deleteDialog(context, 'total');
                       }
                     },
                     itemBuilder: (BuildContext context) {
@@ -469,7 +472,9 @@ class _MemberRecruitPageState extends State<MemberRecruitPage> {
   }
 
   // recruitment 전체 삭제 다이얼로그
-  Future<dynamic> deleteDialog(BuildContext context) {
+  // 파라미터에 [ ]를 덮어서 작성하는 것은 선택적으로, 즉 필요할 때 값을 줄 수 있도록 설정하는 것
+  Future<dynamic> deleteDialog(BuildContext context, String range,
+      [String? category]) {
     return showDialog(
       context: context,
       barrierDismissible: true,
@@ -521,7 +526,14 @@ class _MemberRecruitPageState extends State<MemberRecruitPage> {
                 ),
                 TextButton(
                   onPressed: () async {
-                    await AdminProvider().deleteAllRecruitments();
+                    // 전체 삭제일 경우
+                    if (range == 'total') {
+                      await AdminProvider().deleteAllRecruitments();
+                    }
+                    // 개별 삭제일 경우
+                    else if (range == 'individual' && category != null) {
+                      await AdminProvider().deleteCateRecruitment(category);
+                    }
 
                     if (context.mounted) {
                       // Future.wait : 여러 비동기 작업을 병렬로 실행


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
#167

## ✨ 코드 변경 내용
<!-- 코드 변경에 대한 설명을 적어주세요 -->
### 카테고리 팝업 메뉴 생성
- 개별 삭제라는 팝업 메뉴 생성
- 클릭 시 만들어진 카테고리 이름의 팝업 메뉴 생성
recruitment 카테고리별 삭재 API 연동
- 전체 혹은 개별 삭제 일 경우 api 호출을 다르게 적용
- 파라미터에 []를 덮어서 선택적으로 값을 주도록 작성

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->
### 삭제 전
![Screenshot_1724607019](https://github.com/user-attachments/assets/f092fc9e-ac8c-4264-a0a6-8edbb1a465c0)
### 삭제 후
![Screenshot_1724607025](https://github.com/user-attachments/assets/fc27ebaa-65aa-4672-96d6-33c12bc41a79)

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
- 파라미터에 [ ]를 덮어서 선언