### PR TITLE
[Feat/#181] 작성 내역 구현

### DIFF
--- a/frontend/lib/screens/myOwnerPage_screen.dart
+++ b/frontend/lib/screens/myOwnerPage_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:frontend/providers/announcement_provider.dart';
+import 'package:frontend/screens/boardDetail_screen.dart';
 import 'package:frontend/screens/home_screen.dart';
 import 'package:frontend/widgets/account_widget.dart';
 import 'package:frontend/widgets/profile_widget.dart';
@@ -198,6 +199,16 @@ class _MyOwnerPageState extends State<MyOwnerPage> {
                         return Column(
                           children: [
                             ListTile(
+                              onTap: () {
+                                Navigator.push(
+                                  context,
+                                  MaterialPageRoute(
+                                    builder: (context) => BoardDetailPage(
+                                      announcementId: selectedBoard['id'],
+                                    ),
+                                  ),
+                                );
+                              },
                               title: Text(
                                 '[ ${engToKorCate(selectedBoard['announcementCategory'])} ]',
                                 style: const TextStyle(


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
#181

## ✨ 코드 변경 내용
<!-- 코드 변경에 대한 설명을 적어주세요 -->
### 작성 내역(연도-학기) 보여주기
- 월과 일을 출력해 학기별로 분류하고 중복되는 값들은 제거한 후 '년 학기'로 출력
### 연도 클릭하면 해당 연도의 게시글 보여주기
- onSelectedItemChanged 속성에서 게시글 생성시간을 연도-학기로 추출해 semesterList와 동일한 요소가 있는지 확인
- 동일한게 확인되면 selectedBoardList에 저장
- 영어로 된 카테고리를 한글로 변환하는 함수 구현
- CupertinoPicker에 초기 값 지정
### 게시글 상세 페이지로 넘어가게 구현
- ListTile의 onTap 속성에서 내비게이터 위젯을 사용해서 id로 전달과 동시에 상세 페이지 이동 구현
### 게시글이 2년지나면 1월 1일에 삭제되게 구현하기
- 현재 시간을 구해 게시글 생성시간의 차이를 구해 2년 이상이면 게시글 삭제 호출 후 게시글 조회
- 현재시간이 1월 1일인지 확인
- 메서드를 전체, 학년, 경진대회, 계절, 기업 공지글에 다 적용

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->
### 선택된 게시글
![선택된 게시글](https://github.com/user-attachments/assets/5a33a5b5-eb37-47a7-b2ad-b9b30e14b1cc)
### 작성 내역
![작성 내역 쿠페르티노](https://github.com/user-attachments/assets/14f04b2d-9219-4f44-a5f1-db84fa3804b6)
### 게시글 삭제 콘솔
<img width="480" alt="게시글 삭제 콘솔" src="https://github.com/user-attachments/assets/ddbfb832-26c8-454b-8170-da04f2dde496">


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
DateTime