### PR TITLE
[feat : #189] 다른 사람 프로젝트 경험 조회 api 연동

### DIFF
--- a/frontend/lib/providers/projectExperience_provider.dart
+++ b/frontend/lib/providers/projectExperience_provider.dart
@@ -7,6 +7,7 @@ class ProjectExperienceProvider with ChangeNotifier {
 
   List<ProjectExperience> projectExperiences =
       []; // DataTable에 표시할 프로젝트 경험 정보 리스트
+  List<ProjectExperience> memberExperiences = [];
 
   // 프로젝트 경험 정보를 담는 메소드를 호출(그래야만 프로젝트 경험 정보를 projectExperiences에 담고 반환할 수 있음)
   // projectExperiences 반환
@@ -55,6 +56,22 @@ class ProjectExperienceProvider with ChangeNotifier {
       projectExperiences = fetchExperiences;
 
       notifyListeners(); // 상태 변경을 알림
+    } catch (e) {
+      print(e);
+    }
+  }
+
+  // 다른 사람 프로젝트 경험 조회
+  Future<void> fetchMemberExperiences(int memberId) async {
+    try {
+      // 특정 사용자의 프로젝트 경험을 가져옴
+      List<ProjectExperience> fetchedMemberExperiences =
+          await service.fetchMemberExperiences(memberId);
+
+      // 가져온 프로젝트 경험을 memberExperiences 리스트에 할당
+      memberExperiences = fetchedMemberExperiences;
+
+      notifyListeners(); // 상태 변경 알림
     } catch (e) {
       print(e);
     }

--- a/frontend/lib/screens/experience_screen.dart
+++ b/frontend/lib/screens/experience_screen.dart
@@ -1,7 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:frontend/models/projectExperience_model.dart';
-import 'package:frontend/providers/projectExperience_provider.dart';
-import 'package:provider/provider.dart';
 
 class ExperiencePage extends StatefulWidget {
   final List<ProjectExperience> experiences;
@@ -64,6 +62,7 @@ class ExperiencePageState extends State<ExperiencePage> {
           children: [
             Row(
               children: [
+                // 이름을 제목으로 설정하여 동적으로 표시
                 Text(
                   '✨${widget.name}의 빛나는 경험✨',
                   style: const TextStyle(
@@ -71,102 +70,65 @@ class ExperiencePageState extends State<ExperiencePage> {
                     fontWeight: FontWeight.bold,
                   ),
                 ),
-                const SizedBox(width: 10),
-                const Spacer(),
-                Visibility(
-                  visible: _isExpanded.contains(true),
-                  child: Row(
-                    children: [
-                      GestureDetector(
-                        onTap: () {
-                          _editSelectedExperience();
-                        },
-                        child: Container(
-                          height: 20,
-                          width: 100,
-                          margin: const EdgeInsets.only(left: 10),
-                          decoration: BoxDecoration(
-                            color: const Color(0xFF2A72E7),
-                            borderRadius: BorderRadius.circular(6),
-                          ),
-                          child: const Center(
-                            child: Text(
-                              '경험 수정하기',
-                              style: TextStyle(
-                                fontSize: 10,
-                                fontWeight: FontWeight.bold,
-                                color: Colors.white,
-                              ),
-                            ),
-                          ),
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
               ],
             ),
             const SizedBox(height: 20),
             Expanded(
-              child: Consumer<ProjectExperienceProvider>(
-                builder: (context, provider, child) {
-                  return ListView.builder(
-                    itemCount: provider.projectExperiences.length,
-                    itemBuilder: (context, index) {
-                      final experience = provider.projectExperiences[index];
-                      return Column(
+              child: ListView.builder(
+                itemCount: widget.experiences.length,
+                itemBuilder: (context, index) {
+                  final experience = widget.experiences[index];
+                  return Column(
+                    children: [
+                      ExpansionTile(
+                        title: userInfo(
+                          title: '프로젝트명',
+                          titleSize: 20,
+                          info: experience.experienceName,
+                        ),
+                        onExpansionChanged: (bool expanded) {
+                          setState(() {
+                            _isExpanded[index] = expanded;
+                          });
+                        },
                         children: [
-                          ExpansionTile(
-                            title: userInfo(
-                              title: '프로젝트명',
-                              titleSize: 20,
-                              info: experience.experienceName,
-                            ),
-                            onExpansionChanged: (bool expanded) {
-                              setState(() {
-                                _isExpanded[index] = expanded;
-                              });
-                            },
-                            children: [
-                              Padding(
-                                padding: const EdgeInsets.symmetric(
-                                    horizontal: 20.0),
-                                child: Column(
-                                  children: [
-                                    userInfo(
-                                      title: '나의 역할',
-                                      titleSize: 18,
-                                      info: experience.experienceRole,
-                                    ),
-                                    userInfo(
-                                      title: '프로젝트 경험',
-                                      titleSize: 18,
-                                      info: experience.experienceContent,
-                                    ),
-                                    userInfo(
-                                      title: '깃허브 프로젝트 링크',
-                                      titleSize: 18,
-                                      info: experience.experienceGithub,
-                                    ),
-                                    userInfo(
-                                      title: '직무',
-                                      titleSize: 18,
-                                      info: experience.experienceJob,
-                                    ),
-                                    userInfo(
-                                      title: '프로젝트 기간',
-                                      titleSize: 18,
-                                      info: experience.experienceDate,
-                                    ),
-                                  ],
+                          Padding(
+                            padding:
+                                const EdgeInsets.symmetric(horizontal: 20.0),
+                            child: Column(
+                              children: [
+                                userInfo(
+                                  title: '나의 역할',
+                                  titleSize: 18,
+                                  info: experience.experienceRole,
                                 ),
-                              ),
-                            ],
+                                userInfo(
+                                  title: '프로젝트 경험',
+                                  titleSize: 18,
+                                  info: experience.experienceContent,
+                                ),
+                                userInfo(
+                                  title: '깃허브 프로젝트 링크',
+                                  titleSize: 18,
+                                  info: experience.experienceGithub,
+                                ),
+                                userInfo(
+                                  title: '직무',
+                                  titleSize: 18,
+                                  info: experience.experienceJob,
+                                ),
+                                userInfo(
+                                  title: '프로젝트 기간',
+                                  titleSize: 18,
+                                  info: experience.experienceDate,
+                                ),
+                              ],
+                            ),
                           ),
-                          const SizedBox(height: 10),
                         ],
-                      );
-                    },
+                      ),
+                      const SizedBox(height: 10),
+                    ],
                   );
                 },
               ),
@@ -207,107 +169,6 @@ class ExperiencePageState extends State<ExperiencePage> {
           ),
         ),
       ],
-    );
-  }
-
-  // 선택한 경험 수정하는 메서드
-  void _editSelectedExperience() {
-    // _isExpanded 리스트에서 확장된 타일의 인덱스 찾음
-    final selectedIndex = _isExpanded.indexWhere((expanded) => expanded);
-    // 확장된 타일이 있는 경우
-    if (selectedIndex != -1) {
-      // 해당 인덱스의 경험 데이터를 가져옴
-      final experience = context
-          .read<ProjectExperienceProvider>()
-          .projectExperiences[selectedIndex];
-      // 경험 수정 다이얼로그를 표시
-      _showEditExperienceDialog(context, experience, selectedIndex);
-    }
-  }
-
-  // 경험 수정 다이얼로그
-  void _showEditExperienceDialog(
-      BuildContext context, ProjectExperience experience, int index) {
-    // 각 필드를 위한 TextEditingController를 생성하고, 초기값을 설정
-    final TextEditingController nameController =
-        TextEditingController(text: experience.experienceName);
-    final TextEditingController roleController =
-        TextEditingController(text: experience.experienceRole);
-    final TextEditingController contentController =
-        TextEditingController(text: experience.experienceContent);
-    final TextEditingController githubController =
-        TextEditingController(text: experience.experienceGithub);
-    final TextEditingController jobController =
-        TextEditingController(text: experience.experienceJob);
-    final TextEditingController dateController =
-        TextEditingController(text: experience.experienceDate);
-
-    // 다이얼로그를 생성하고 표시
-    showDialog(
-      context: context,
-      builder: (context) {
-        return AlertDialog(
-          title: const Text('경험 수정하기'),
-          content: SingleChildScrollView(
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                // 각각의 TextField를 생성하고 해당 컨트롤러와 라벨을 설정
-                _buildTextField(nameController, '프로젝트명'),
-                _buildTextField(roleController, '나의 역할'),
-                _buildTextField(contentController, '프로젝트 경험'),
-                _buildTextField(githubController, '깃허브 프로젝트 링크'),
-                _buildTextField(jobController, '직무'),
-                _buildTextField(dateController, '프로젝트 기간'),
-              ],
-            ),
-          ),
-          actions: [
-            TextButton(
-              onPressed: () {
-                Navigator.of(context).pop();
-              },
-              child: const Text('취소'),
-            ),
-            TextButton(
-              onPressed: () {
-                // 업데이트된 경험 데이터를 생성
-                final updatedExperience = ProjectExperience(
-                  id: experience.id, // 기존 ID 유지
-                  experienceName: nameController.text,
-                  experienceRole: roleController.text,
-                  experienceContent: contentController.text,
-                  experienceGithub: githubController.text,
-                  experienceJob: jobController.text,
-                  experienceDate: dateController.text,
-                );
-
-                // Provider를 사용하여 경험 데이터를 업데이트하고, UI를 갱신
-                Provider.of<ProjectExperienceProvider>(context, listen: false)
-                    .updateProjectExperience(updatedExperience)
-                    .then((_) {
-                  Navigator.of(context).pop();
-                });
-              },
-              child: const Text('저장'),
-            ),
-          ],
-        );
-      },
-    );
-  }
-
-  // 텍스트 필드를 생성하는 헬퍼 함수
-  Widget _buildTextField(TextEditingController controller, String label) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 8.0),
-      child: TextField(
-        controller: controller,
-        decoration: InputDecoration(
-          labelText: label,
-          border: const OutlineInputBorder(),
-        ),
-      ),
     );
   }
 }

--- a/frontend/lib/services/projectExperience_service.dart
+++ b/frontend/lib/services/projectExperience_service.dart
@@ -20,7 +20,6 @@ class ProjectExperienceService {
     const String baseUrl = 'http://127.0.0.1:9000/api/v1/member-experience';
     // const String baseUrl = 'http://10.0.2.2:9000/api/v1/member-experience';
 
-
     final token = await getToken();
     if (token == null) {
       throw Exception('Access token을 찾을 수 없습니다.');
@@ -109,6 +108,40 @@ class ProjectExperienceService {
       return fetchExperiences;
     } else {
       print("내 프로젝트 경험 조회 실패");
+      return [];
+    }
+  }
+
+  // 다른 사람의 프로젝트 경험 조회 API
+  Future<List<ProjectExperience>> fetchMemberExperiences(int memberId) async {
+    final String baseUrl =
+        'http://127.0.0.1:9000/api/v1/member-experience/$memberId';
+
+    final token = await getToken();
+    if (token == null) {
+      throw Exception('Access token을 찾을 수 없습니다.');
+    }
+
+    final url = Uri.parse(baseUrl);
+    final response = await http.get(
+      url,
+      headers: <String, String>{
+        'access': token,
+      },
+    );
+
+    final responseData = jsonDecode(utf8.decode(response.bodyBytes));
+
+    if (response.statusCode == 200) {
+      List<ProjectExperience> memberExperiences = (responseData['data'] as List)
+          .map((projectExperienceData) =>
+              ProjectExperience.fromJson(projectExperienceData))
+          .toList();
+
+      print("다른 사람의 프로젝트 경험 조회 성공: $memberExperiences");
+      return memberExperiences;
+    } else {
+      print("다른 사람의 프로젝트 경험 조회 실패");
       return [];
     }
   }


### PR DESCRIPTION
## 📌 관련 이슈
#189 

## ✨ 코드 변경 내용
- recruitList에서 memberId가 일치하는 멤버 적용해서 이름 UI에 표시
- memberId 추출해서 해당 멤버의 프로젝트 경험 조회할 수 있도록
- service 작성
- provider 작성

## 📸 스크린샷(선택)
https://github.com/user-attachments/assets/d554e4f1-8a83-4623-92e0-a92b09c9c7d4



## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
