### PR TITLE
[Fix/#187] 게시글 숨김/삭제 위치 변경

### DIFF
--- a/frontend/lib/screens/boardDetail_screen.dart
+++ b/frontend/lib/screens/boardDetail_screen.dart
@@ -155,19 +155,8 @@ class _BoardDetailPageState extends State<BoardDetailPage> {
           padding: const EdgeInsets.only(right: 40.0),
           child: IconButton(
             onPressed: () async {
-              if (widget.category == 'CORSEA') {
-                Navigator.pushNamedAndRemoveUntil(
-                    context, '/corSea-board', (route) => false);
-              } else if (widget.category == 'ACADEMIC_ALL') {
-                Navigator.pushNamedAndRemoveUntil(
-                    context, '/grade-board', (route) => false);
-              } else if (widget.category == 'CONTEST') {
-                Navigator.pushNamedAndRemoveUntil(
-                    context, '/contest-board', (route) => false);
-              } else {
-                Navigator.pushNamedAndRemoveUntil(
-                    context, '/total-board', (route) => false);
-              }
+              // 공지 카테고리에 맞는 Navigator 메서드
+              pushNamedAndRemoveUntil();
             },
             icon: const Icon(
               Icons.arrow_back,
@@ -238,7 +227,7 @@ class _BoardDetailPageState extends State<BoardDetailPage> {
                               popUpItem('URL 공유', PopUpItem.popUpItem1, () {}),
                               if (userRole == 'ROLE_ADMIN')
                                 const PopupMenuDivider(),
-                              if (userRole == 'ROLE_ADMIN')
+                              if (userRole == 'ROLE_ADMIN') ...[
                                 popUpItem('수정', PopUpItem.popUpItem2, () async {
                                   // BoardUpdatePage에서 수정된 게시글 정보를 받아옴
                                   final updateBoard = await Navigator.push(
@@ -260,6 +249,40 @@ class _BoardDetailPageState extends State<BoardDetailPage> {
                                     });
                                   }
                                 }),
+                                const PopupMenuDivider(),
+                                popUpItem(
+                                  '숨김',
+                                  PopUpItem.popUpItem3,
+                                  () async {
+                                    await Provider.of<AnnouncementProvider>(
+                                            context,
+                                            listen: false)
+                                        .hiddenBoard(board, board['id']);
+
+                                    if (context.mounted) {
+                                      pushNamedAndRemoveUntil();
+                                      alertSnackBar(context, '숨김이 완료되었습니다');
+                                    }
+                                  },
+                                ),
+                                const PopupMenuDivider(),
+                                popUpItem(
+                                  '삭제',
+                                  PopUpItem.popUpItem4,
+                                  () async {
+                                    print('id: ${board['id']}');
+                                    await Provider.of<AnnouncementProvider>(
+                                            context,
+                                            listen: false)
+                                        .deletedBoard(board['id']);
+
+                                    if (context.mounted) {
+                                      pushNamedAndRemoveUntil();
+                                      alertSnackBar(context, '삭제가 완료되었습니다');
+                                    }
+                                  },
+                                ),
+                              ]
                             ];
                           },
                           child: const Icon(Icons.more_vert),
@@ -445,6 +468,23 @@ class _BoardDetailPageState extends State<BoardDetailPage> {
               ),
             ),
     );
+  }
+
+  // 공지 카테고리에 맞는 Navigator 메서드
+  void pushNamedAndRemoveUntil() {
+    if (widget.category == 'CORSEA') {
+      Navigator.pushNamedAndRemoveUntil(
+          context, '/corSea-board', (route) => false);
+    } else if (widget.category == 'ACADEMIC_ALL') {
+      Navigator.pushNamedAndRemoveUntil(
+          context, '/grade-board', (route) => false);
+    } else if (widget.category == 'CONTEST') {
+      Navigator.pushNamedAndRemoveUntil(
+          context, '/contest-board', (route) => false);
+    } else {
+      Navigator.pushNamedAndRemoveUntil(
+          context, '/total-board', (route) => false);
+    }
   }
 }
 

--- a/frontend/lib/screens/boardDetail_screen.dart
+++ b/frontend/lib/screens/boardDetail_screen.dart
@@ -6,7 +6,6 @@ import 'package:flutter/material.dart';
 import 'package:frontend/models/vote_model.dart';
 import 'package:frontend/providers/announcement_provider.dart';
 import 'package:path/path.dart' as path;
-import 'package:http/http.dart' as http;
 import 'package:frontend/screens/myOwnerPage_screen.dart';
 import 'package:frontend/screens/myUserPage_screen.dart';
 import 'package:frontend/widgets/vote_widget.dart';
@@ -22,10 +21,11 @@ class BoardDetailPage extends StatefulWidget {
   State<BoardDetailPage> createState() => _BoardDetailPageState();
 }
 
-PopupMenuItem<PopUpItem> popUpItem(String text, PopUpItem item) {
+PopupMenuItem<PopUpItem> popUpItem(
+    String text, PopUpItem item, Function() onTap) {
   return PopupMenuItem<PopUpItem>(
     enabled: true, // 팝업메뉴 호출
-    onTap: () {},
+    onTap: onTap,
     value: item,
     height: 25,
     child: Center(
@@ -41,7 +41,7 @@ PopupMenuItem<PopUpItem> popUpItem(String text, PopUpItem item) {
   );
 }
 
-enum PopUpItem { popUpItem1, popUpItem2 } // 팝업 아이템
+enum PopUpItem { popUpItem1, popUpItem2, popUpItem3, popUpItem4 } // 팝업 아이템
 
 class _BoardDetailPageState extends State<BoardDetailPage> {
   Map<String, dynamic> board = {};
@@ -208,10 +208,54 @@ class _BoardDetailPageState extends State<BoardDetailPage> {
                     color: const Color(0xFFEFF0F2),
                     itemBuilder: (BuildContext context) {
                       return [
-                        popUpItem('URL 공유', PopUpItem.popUpItem1),
-                        if (userRole == 'ROLE_ADMIN') const PopupMenuDivider(),
-                        if (userRole == 'ROLE_ADMIN')
-                          popUpItem('수정', PopUpItem.popUpItem2),
+                        popUpItem('URL 공유', PopUpItem.popUpItem1, () {}),
+                        if (userRole == 'ROLE_ADMIN') ...[
+                          const PopupMenuDivider(),
+                          popUpItem('수정', PopUpItem.popUpItem2, () async {
+                            // 수정 페이지에서 리턴값을 받아서 board에 저장
+                            // final data = await Navigator.push(
+                            //   context,
+                            //   MaterialPageRoute(
+                            //     builder: (context) =>
+                            //         BoardUpdatePage(board: board),
+                            //   ),
+                            // );
+                            // setState(() {
+                            //   board = data;
+                            // });
+                          }),
+                          const PopupMenuDivider(),
+                          popUpItem(
+                            '숨김',
+                            PopUpItem.popUpItem3,
+                            () async {
+                              await Provider.of<AnnouncementProvider>(context,
+                                      listen: false)
+                                  .hiddenBoard(board, board['id']);
+
+                              if (context.mounted) {
+                                alertSnackBar(context, '숨김이 완료되었습니다');
+                              }
+                            },
+                          ),
+                          const PopupMenuDivider(),
+                          popUpItem(
+                            '삭제',
+                            PopUpItem.popUpItem4,
+                            () async {
+                              print('id: ${board['id']}');
+                              await Provider.of<AnnouncementProvider>(context,
+                                      listen: false)
+                                  .deletedBoard(board['id']);
+
+                              if (context.mounted) {
+                                Navigator.popAndPushNamed(
+                                    context, '/total-board');
+                                alertSnackBar(context, '삭제가 완료되었습니다');
+                              }
+                            },
+                          ),
+                        ]
                       ];
                     },
                     child: const Icon(Icons.more_vert),

--- a/frontend/lib/screens/hiddenList_screen.dart
+++ b/frontend/lib/screens/hiddenList_screen.dart
@@ -122,6 +122,11 @@ class _HiddenPageState extends State<HiddenPage> {
                     await Provider.of<AnnouncementProvider>(context,
                             listen: false)
                         .fetchHiddenBoard();
+
+                    // 숨김 해제 후 새로고침할 때 숨김 해제 버튼 없애기 위해 isHidDel를 false로 설정
+                    setState(() {
+                      isHidDel = false;
+                    });
                   }
                 }
               },

--- a/frontend/lib/screens/totalBoard_screen.dart
+++ b/frontend/lib/screens/totalBoard_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:frontend/providers/announcement_provider.dart';
+import 'package:frontend/screens/boardDetail_screen.dart';
 import 'package:frontend/screens/hiddenList_screen.dart';
 import 'package:frontend/screens/write_screen.dart';
 import 'package:frontend/services/login_services.dart';
@@ -126,7 +127,7 @@ class _TotalBoardPageState extends State<TotalBoardPage> {
                             context,
                             MaterialPageRoute(
                               builder: (context) =>
-                                  HiddenPage(category: 'TOTAL'),
+                                  const HiddenPage(category: 'TOTAL'),
                             ),
                           );
                         }),
@@ -141,104 +142,12 @@ class _TotalBoardPageState extends State<TotalBoardPage> {
               child: Board(
                 boardList: boardList,
                 total: true,
-                onBoardSelected: (board) {
-                  setState(() {
-                    selectedBoard = board;
-                    isHidDel = !isHidDel; // 숨김/삭제 버튼 표시
-                  });
-                },
+                isClicked: true,
               ),
             ),
           ],
         ),
       ),
-      // 숨김/삭제 버튼(isEdited 값을 저장한 isHidDel)
-      bottomNavigationBar: isHidDel
-          ? Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                SizedBox(
-                  width: MediaQuery.of(context).size.width / 2,
-                  height: MediaQuery.of(context).size.height / 12,
-                  child: ElevatedButton(
-                    onPressed: () async {
-                      if (selectedBoard != null) {
-                        print('id: ${selectedBoard!['id']}');
-                        await Provider.of<AnnouncementProvider>(context,
-                                listen: false)
-                            .hiddenBoard(selectedBoard!, selectedBoard!['id']);
-
-                        // 전체 boardList를 다시 불러옴
-                        if (context.mounted) {
-                          await Provider.of<AnnouncementProvider>(context,
-                                  listen: false)
-                              .fetchAllBoards();
-                        }
-                        setState(() {
-                          isHidDel = false; // 숨김/삭제 버튼 숨기기
-                          selectedBoard = null; // 선택된 게시글 초기화
-                        });
-                      }
-                    },
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: const Color(0xFFFAFAFE),
-                      minimumSize: const Size(205, 75),
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(0),
-                      ),
-                    ),
-                    child: const Text(
-                      '숨김',
-                      style: TextStyle(
-                        color: Color(0xFF7D7D7F),
-                        fontSize: 20,
-                        fontWeight: FontWeight.bold,
-                      ),
-                    ),
-                  ),
-                ),
-                SizedBox(
-                  width: MediaQuery.of(context).size.width / 2,
-                  height: MediaQuery.of(context).size.height / 12,
-                  child: ElevatedButton(
-                    onPressed: () async {
-                      if (selectedBoard != null) {
-                        print('id: ${selectedBoard!['id']}');
-                        await Provider.of<AnnouncementProvider>(context,
-                                listen: false)
-                            .deletedBoard(selectedBoard!['id']);
-
-                        // 전체 boardList를 다시 불러옴
-                        if (context.mounted) {
-                          await Provider.of<AnnouncementProvider>(context,
-                                  listen: false)
-                              .fetchAllBoards();
-                        }
-                        setState(() {
-                          isHidDel = false; // 숨김/삭제 버튼 숨기기
-                          selectedBoard = null; // 선택된 게시글 초기화
-                        });
-                      }
-                    },
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: const Color(0xFFFAFAFE),
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(0),
-                      ),
-                    ),
-                    child: const Text(
-                      '삭제',
-                      style: TextStyle(
-                        color: Color(0xFF7D7D7F),
-                        fontSize: 20,
-                        fontWeight: FontWeight.bold,
-                      ),
-                    ),
-                  ),
-                ),
-              ],
-            )
-          : null,
     );
   }
 }

--- a/frontend/lib/widgets/board_widget.dart
+++ b/frontend/lib/widgets/board_widget.dart
@@ -99,6 +99,16 @@ class _BoardState extends State<Board> {
         final category = _getCategoryName(board['announcementCategory']);
         // final isSelected = selectedBoardIndex == index; // 현재 게시글이 선택된 게시글인지 확인
 
+        // 제목이 20자 이상일 때 "..." 처리
+        String truncatedTitle = board['announcementTitle'].length > 20
+            ? '${board['announcementTitle'].substring(0, 20)}...'
+            : board['announcementTitle'];
+
+        // 내용이 30자 이상일 때 "..." 처리
+        String truncatedContent = board['announcementContent'].length > 30
+            ? '${board['announcementContent'].substring(0, 30)}...'
+            : board['announcementContent'];
+
         return Column(
           children: [
             GestureDetector(
@@ -159,7 +169,7 @@ class _BoardState extends State<Board> {
                           Row(
                             children: [
                               Text(
-                                board['announcementTitle'],
+                                truncatedTitle,
                                 style: const TextStyle(
                                   fontSize: 16,
                                   fontWeight: FontWeight.bold,
@@ -179,7 +189,7 @@ class _BoardState extends State<Board> {
                       ),
                       const SizedBox(height: 7),
                       Text(
-                        board['announcementContent'],
+                        truncatedContent,
                         style: const TextStyle(
                           fontWeight: FontWeight.bold,
                           fontSize: 14,


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
#187

## ✨ 코드 변경 내용
<!-- 코드 변경에 대한 설명을 적어주세요 -->
### 상세 페이지에서 숨김 삭제 기능 구현
- 게시글 목록 페이지에서 길게 눌러서 숨김 삭제 기능에서 통일성을 위해 상세 페이지의 팝업 메뉴에서 구현할 수 있게 변경
### 숨김 및 삭제 버튼 위치 변경
- 공지 카테고리에 맞게 이전페이지로 이동하는 함수를 생성
- 숨김 페이지에서 숨김 해제 후 새로고침할 때 숨김 해제 버튼 없애기 위해 isHidDel를 false로 설정
- 제목, 내용 각각 20, 30자 이상일 때 ... 처리

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->
![Screenshot_1726469660](https://github.com/user-attachments/assets/231c4021-f6e6-44f2-b00d-d07f5535ae89)


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
