### PR TITLE
[Feat/#186] 홈화면에서 공지 띄우기

### DIFF
--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -12,6 +12,7 @@ import 'package:frontend/screens/contestBoard_screen.dart';
 import 'package:frontend/screens/editField_screen.dart';
 import 'package:frontend/screens/editTool_screen.dart';
 import 'package:frontend/screens/hiddenList_screen.dart';
+import 'package:frontend/screens/myOwnerPage_screen.dart';
 import 'package:frontend/screens/totalBoard_screen.dart';
 import 'package:frontend/screens/write_screen.dart';
 import 'package:get/get.dart';
@@ -201,6 +202,7 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
         '/add_member': (context) => const AddMemberPage(),
         '/user-info': (context) => const UserInfoPage(),
         '/myuser': (context) => const MyUserPage(),
+        '/myowner': (context) => const MyOwnerPage(),
         '/set-profile': (context) => const SetProfilePage(),
         '/member-experience': (context) => const SetExperiencePage(),
         '/experience': (context) => const ExperiencePage(

--- a/frontend/lib/screens/boardDetail_screen.dart
+++ b/frontend/lib/screens/boardDetail_screen.dart
@@ -211,11 +211,18 @@ class _BoardDetailPageState extends State<BoardDetailPage> {
                       mainAxisAlignment: MainAxisAlignment.spaceBetween,
                       children: [
                         // 게시글 제목
-                        Text(
-                          board['announcementTitle'] ?? '',
-                          style: const TextStyle(
-                            fontSize: 20,
-                            fontWeight: FontWeight.bold,
+                        Flexible(
+                          child: RichText(
+                            overflow: TextOverflow.clip,
+                            maxLines: 5,
+                            text: TextSpan(
+                              text: board['announcementTitle'] ?? '',
+                              style: const TextStyle(
+                                fontSize: 20,
+                                fontWeight: FontWeight.bold,
+                                color: Colors.black,
+                              ),
+                            ),
                           ),
                         ),
 
@@ -484,6 +491,8 @@ class _BoardDetailPageState extends State<BoardDetailPage> {
     } else if (widget.category == 'TOTAL') {
       Navigator.pushNamedAndRemoveUntil(
           context, '/total-board', (route) => false);
+    } else if (widget.category == 'PROFILE') {
+      Navigator.pushNamedAndRemoveUntil(context, '/myowner', (route) => false);
     } else {
       Navigator.pushNamedAndRemoveUntil(context, '/homepage', (route) => false);
     }

--- a/frontend/lib/screens/boardDetail_screen.dart
+++ b/frontend/lib/screens/boardDetail_screen.dart
@@ -481,9 +481,11 @@ class _BoardDetailPageState extends State<BoardDetailPage> {
     } else if (widget.category == 'CONTEST') {
       Navigator.pushNamedAndRemoveUntil(
           context, '/contest-board', (route) => false);
-    } else {
+    } else if (widget.category == 'TOTAL') {
       Navigator.pushNamedAndRemoveUntil(
           context, '/total-board', (route) => false);
+    } else {
+      Navigator.pushNamedAndRemoveUntil(context, '/homepage', (route) => false);
     }
   }
 }

--- a/frontend/lib/screens/home_screen.dart
+++ b/frontend/lib/screens/home_screen.dart
@@ -2,6 +2,7 @@ import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/material.dart';
 import 'package:frontend/providers/announcement_provider.dart';
 import 'package:frontend/providers/profile_provider.dart';
+import 'package:frontend/screens/boardDetail_screen.dart';
 import 'package:frontend/screens/myOwnerPage_screen.dart';
 import 'package:frontend/services/login_services.dart';
 import 'package:provider/provider.dart';
@@ -384,60 +385,74 @@ class _HomePageState extends State<HomePage> {
 
                               return Row(
                                 children: [
-                                  Container(
-                                    width:
-                                        MediaQuery.of(context).size.width / 2,
-                                    padding: const EdgeInsets.all(10.0),
-                                    decoration: BoxDecoration(
-                                      color: const Color(0xFFDBE7FB),
-                                      borderRadius: BorderRadius.circular(15.0),
-                                      border: Border.all(
-                                        color: const Color(0xFF2B72E7)
-                                            .withOpacity(0.25),
-                                        width: 1,
+                                  GestureDetector(
+                                    onTap: () {
+                                      Navigator.push(
+                                        context,
+                                        MaterialPageRoute(
+                                          builder: (context) => BoardDetailPage(
+                                            announcementId: board['id'],
+                                            category: 'HOME',
+                                          ),
+                                        ),
+                                      );
+                                    },
+                                    child: Container(
+                                      width:
+                                          MediaQuery.of(context).size.width / 2,
+                                      padding: const EdgeInsets.all(10.0),
+                                      decoration: BoxDecoration(
+                                        color: const Color(0xFFDBE7FB),
+                                        borderRadius:
+                                            BorderRadius.circular(15.0),
+                                        border: Border.all(
+                                          color: const Color(0xFF2B72E7)
+                                              .withOpacity(0.25),
+                                          width: 1,
+                                        ),
                                       ),
-                                    ),
-                                    child: Column(
-                                      crossAxisAlignment:
-                                          CrossAxisAlignment.start,
-                                      children: [
-                                        Text(
-                                          truncatedTitle, // 정해진 길이만큼 출력한 공지글 제목
-                                          style: const TextStyle(
-                                            color: Colors.black,
-                                            fontSize: 14,
-                                            fontWeight: FontWeight.bold,
+                                      child: Column(
+                                        crossAxisAlignment:
+                                            CrossAxisAlignment.start,
+                                        children: [
+                                          Text(
+                                            truncatedTitle, // 정해진 길이만큼 출력한 공지글 제목
+                                            style: const TextStyle(
+                                              color: Colors.black,
+                                              fontSize: 14,
+                                              fontWeight: FontWeight.bold,
+                                            ),
                                           ),
-                                        ),
-                                        Text(
-                                          truncatedContent, // 줄바꿈 제거 후 길이만큼 출력한 공지글 내용
-                                          style: const TextStyle(
-                                            color: Colors.black54,
-                                            fontSize: 12,
+                                          Text(
+                                            truncatedContent, // 줄바꿈 제거 후 길이만큼 출력한 공지글 내용
+                                            style: const TextStyle(
+                                              color: Colors.black54,
+                                              fontSize: 12,
+                                            ),
                                           ),
-                                        ),
-                                        const SizedBox(height: 29),
-                                        const Row(
-                                          children: [
-                                            Text(
-                                              '더보기',
-                                              style: TextStyle(
-                                                color: Colors.black54,
-                                                fontSize: 12,
-                                                fontWeight: FontWeight.bold,
+                                          const SizedBox(height: 29),
+                                          const Row(
+                                            children: [
+                                              Text(
+                                                '더보기',
+                                                style: TextStyle(
+                                                  color: Colors.black54,
+                                                  fontSize: 12,
+                                                  fontWeight: FontWeight.bold,
+                                                ),
                                               ),
-                                            ),
-                                            Padding(
-                                              padding:
-                                                  EdgeInsets.only(right: 30.0),
-                                              child: Icon(
-                                                  Icons.arrow_forward_ios,
-                                                  size: 14,
-                                                  color: Colors.black54),
-                                            ),
-                                          ],
-                                        ),
-                                      ],
+                                              Padding(
+                                                padding: EdgeInsets.only(
+                                                    right: 30.0),
+                                                child: Icon(
+                                                    Icons.arrow_forward_ios,
+                                                    size: 14,
+                                                    color: Colors.black54),
+                                              ),
+                                            ],
+                                          ),
+                                        ],
+                                      ),
                                     ),
                                   ),
                                   const SizedBox(width: 9),

--- a/frontend/lib/screens/home_screen.dart
+++ b/frontend/lib/screens/home_screen.dart
@@ -362,27 +362,6 @@ class _HomePageState extends State<HomePage> {
                                   ? userBoardList[index]
                                   : mustBoardList[index];
 
-                              // 제목이 20자 이상일 때 "..." 처리
-                              String truncatedTitle = board['announcementTitle']
-                                          .length >
-                                      13
-                                  ? '${board['announcementTitle'].substring(0, 13)}...'
-                                  : board['announcementTitle'];
-
-                              // 줄바꿈 제거 후, 내용이 30자 이상일 때 "..." 처리
-                              String announcementContent =
-                                  board['announcementContent']
-                                      .replaceAll('\n', '')
-                                      .replaceAll('\r', '');
-
-                              // 내용이 30자 이상일 때 "..." 처리
-                              String truncatedContent = board[
-                                              'announcementContent']
-                                          .length >
-                                      25
-                                  ? '${announcementContent.substring(0, 25)}...'
-                                  : announcementContent;
-
                               return Row(
                                 children: [
                                   GestureDetector(
@@ -415,19 +394,31 @@ class _HomePageState extends State<HomePage> {
                                         crossAxisAlignment:
                                             CrossAxisAlignment.start,
                                         children: [
-                                          Text(
-                                            truncatedTitle, // 정해진 길이만큼 출력한 공지글 제목
-                                            style: const TextStyle(
-                                              color: Colors.black,
-                                              fontSize: 14,
-                                              fontWeight: FontWeight.bold,
+                                          // 컨테이너 크기에 맞게 줄임표를 사용하여 텍스트가 오버플로되었음을 나타냄
+                                          // 공지글 제목
+                                          RichText(
+                                            overflow: TextOverflow.ellipsis,
+                                            text: TextSpan(
+                                              text: board['announcementTitle'],
+                                              style: const TextStyle(
+                                                color: Colors.black,
+                                                fontSize: 14,
+                                                fontWeight: FontWeight.bold,
+                                              ),
                                             ),
                                           ),
-                                          Text(
-                                            truncatedContent, // 줄바꿈 제거 후 길이만큼 출력한 공지글 내용
-                                            style: const TextStyle(
-                                              color: Colors.black54,
-                                              fontSize: 12,
+
+                                          // 공지글 내용
+                                          RichText(
+                                            overflow: TextOverflow.ellipsis,
+                                            maxLines: 2,
+                                            text: TextSpan(
+                                              text:
+                                                  board['announcementContent'],
+                                              style: const TextStyle(
+                                                color: Colors.black54,
+                                                fontSize: 12,
+                                              ),
                                             ),
                                           ),
                                           const SizedBox(height: 29),

--- a/frontend/lib/screens/home_screen.dart
+++ b/frontend/lib/screens/home_screen.dart
@@ -1,5 +1,6 @@
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/material.dart';
+import 'package:frontend/providers/announcement_provider.dart';
 import 'package:frontend/providers/profile_provider.dart';
 import 'package:frontend/screens/myOwnerPage_screen.dart';
 import 'package:frontend/services/login_services.dart';
@@ -48,6 +49,7 @@ class _HomePageState extends State<HomePage> {
   DateTime? _rangeEnd;
 
   String userRole = '';
+  int? level;
 
   List<Map<String, dynamic>> voteList = [
     {
@@ -67,13 +69,27 @@ class _HomePageState extends State<HomePage> {
     },
   ];
 
+  List<Map<String, dynamic>> userBoardList =
+      []; // 학생에게 보여질 공지글(해당 학년의 공지글만 보여주기 위해)
+
   // 위젯의 상태 초기화
   @override
   void initState() {
     super.initState();
     _selectedDay = _focuseDay;
 
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      _initializeData();
+    });
+
     _loadCredentials();
+  }
+
+  // 비동기 초기화 메서드
+  Future<void> _initializeData() async {
+    await Provider.of<AnnouncementProvider>(context, listen: false)
+        .fetchAllBoards();
+    getData(); // 전체 공지 api가 먼저 호출되어야 홈화면에 공지를 띄울 수 있음.
   }
 
   // 역할을 로드하는 메서드
@@ -82,7 +98,9 @@ class _HomePageState extends State<HomePage> {
     final credentials = await loginAPI.loadCredentials(); // 저장된 자격증명 로드
     setState(() {
       userRole = credentials['userRole']; // 로그인 정보에 있는 level를 가져와 저장
+      level = credentials['level'];
     });
+    print('학년: $level');
   }
 
   // 날짜가 선택되었을 때 실행되는 콜백 메서드
@@ -196,17 +214,6 @@ class _HomePageState extends State<HomePage> {
     return token!;
   }
 
-  // 알림 테스트
-  // 푸시 알림 데이터
-  Map<String, dynamic> notificationData = {
-    "id": "1",
-    "title": "Test Notification",
-    "content": "This is a test notification message.",
-    "category": "general",
-    "targetId": 1,
-    "createdAt": "2024-07-28T10:00:00"
-  };
-
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
@@ -307,118 +314,145 @@ class _HomePageState extends State<HomePage> {
                   ),
                 ),
                 const SizedBox(height: 20),
-                SingleChildScrollView(
-                  // 사용자가 스크롤하여 모든 위젯을 볼 수 있음
-                  scrollDirection: Axis.horizontal,
-                  child: Row(
-                    children: [
-                      Container(
-                        // 첫 번째 위젯 박스
-                        width: 216,
-                        padding: const EdgeInsets.all(20.0),
-                        margin: const EdgeInsets.only(right: 9.0),
-                        decoration: BoxDecoration(
-                          color: const Color(0xFFDBE7FB),
-                          borderRadius: BorderRadius.circular(15.0), // 박스 둥근 비율
-                          border: Border.all(
-                            // 박스 테두리
-                            color: const Color(0xFF2B72E7).withOpacity(0.25),
-                            width: 1, // 두께
-                          ),
-                        ),
-                        child: const Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Text(
-                              '우리 학교의 모든 것',
-                              style: TextStyle(
-                                color: Colors.black,
-                                fontSize: 14,
-                                fontWeight: FontWeight.bold,
-                              ),
-                            ),
-                            Text(
-                              '중요한 학교 정보 놓치지 마세요',
-                              style: TextStyle(
-                                color: Colors.black54,
-                                fontSize: 12,
-                              ),
-                            ),
-                            SizedBox(height: 29),
-                            Row(
-                              children: [
-                                Text(
-                                  '더보기',
-                                  style: TextStyle(
-                                    color: Colors.black54,
-                                    fontSize: 12,
-                                    fontWeight: FontWeight.bold,
+
+                // 필독 공지들
+                FutureBuilder(
+                  future: getData(),
+                  builder: (context, snapshot) {
+                    if (snapshot.connectionState == ConnectionState.waiting) {
+                      return const Center(
+                        child: CircularProgressIndicator(),
+                      );
+                    } else if (snapshot.hasError) {
+                      return const Center(
+                        child: Text('데이터를 불러오는 도중 오류가 발생했습니다.'),
+                      );
+                    } else if (snapshot.hasData && snapshot.data!.isNotEmpty) {
+                      List<Map<String, dynamic>> boardList =
+                          snapshot.data as List<Map<String, dynamic>>;
+
+                      // 전체 공지에서 필독 상태인 공지만 필터링한 공지
+                      List<Map<String, dynamic>> mustBoardList =
+                          boardList.where((board) {
+                        return board['announcementImportant'] == true;
+                      }).toList();
+
+                      // 학생일 경우에는 학년까지 필터링해야 함
+                      if (userRole == 'ROLE_USER') {
+                        userBoardList = boardList.where((board) {
+                          return board['announcementLevel'] == level &&
+                              board['announcementImportant'] == true;
+                        }).toList();
+                      }
+
+                      // 공지글이 비어있으면 공지 아이콘들이 최상단에 위치
+                      if (userBoardList.isNotEmpty ||
+                          mustBoardList.isNotEmpty) {
+                        return SizedBox(
+                          height: MediaQuery.of(context).size.height / 6,
+                          child: ListView.builder(
+                            scrollDirection: Axis.horizontal,
+                            itemCount: (userRole == 'ROLE_USER')
+                                ? userBoardList.length
+                                : mustBoardList.length,
+                            shrinkWrap: true, // 높이를 제한하는 데 도움을 줌
+                            itemBuilder: (context, index) {
+                              final board = (userRole == 'ROLE_USER')
+                                  ? userBoardList[index]
+                                  : mustBoardList[index];
+
+                              // 제목이 20자 이상일 때 "..." 처리
+                              String truncatedTitle = board['announcementTitle']
+                                          .length >
+                                      13
+                                  ? '${board['announcementTitle'].substring(0, 13)}...'
+                                  : board['announcementTitle'];
+
+                              // 줄바꿈 제거 후, 내용이 30자 이상일 때 "..." 처리
+                              String announcementContent =
+                                  board['announcementContent']
+                                      .replaceAll('\n', '')
+                                      .replaceAll('\r', '');
+
+                              // 내용이 30자 이상일 때 "..." 처리
+                              String truncatedContent = board[
+                                              'announcementContent']
+                                          .length >
+                                      25
+                                  ? '${announcementContent.substring(0, 25)}...'
+                                  : announcementContent;
+
+                              return Row(
+                                children: [
+                                  Container(
+                                    width:
+                                        MediaQuery.of(context).size.width / 2,
+                                    padding: const EdgeInsets.all(10.0),
+                                    decoration: BoxDecoration(
+                                      color: const Color(0xFFDBE7FB),
+                                      borderRadius: BorderRadius.circular(15.0),
+                                      border: Border.all(
+                                        color: const Color(0xFF2B72E7)
+                                            .withOpacity(0.25),
+                                        width: 1,
+                                      ),
+                                    ),
+                                    child: Column(
+                                      crossAxisAlignment:
+                                          CrossAxisAlignment.start,
+                                      children: [
+                                        Text(
+                                          truncatedTitle, // 정해진 길이만큼 출력한 공지글 제목
+                                          style: const TextStyle(
+                                            color: Colors.black,
+                                            fontSize: 14,
+                                            fontWeight: FontWeight.bold,
+                                          ),
+                                        ),
+                                        Text(
+                                          truncatedContent, // 줄바꿈 제거 후 길이만큼 출력한 공지글 내용
+                                          style: const TextStyle(
+                                            color: Colors.black54,
+                                            fontSize: 12,
+                                          ),
+                                        ),
+                                        const SizedBox(height: 29),
+                                        const Row(
+                                          children: [
+                                            Text(
+                                              '더보기',
+                                              style: TextStyle(
+                                                color: Colors.black54,
+                                                fontSize: 12,
+                                                fontWeight: FontWeight.bold,
+                                              ),
+                                            ),
+                                            Padding(
+                                              padding:
+                                                  EdgeInsets.only(right: 30.0),
+                                              child: Icon(
+                                                  Icons.arrow_forward_ios,
+                                                  size: 14,
+                                                  color: Colors.black54),
+                                            ),
+                                          ],
+                                        ),
+                                      ],
+                                    ),
                                   ),
-                                ),
-                                Padding(
-                                  padding: EdgeInsets.only(right: 30.0),
-                                  child: Icon(Icons.arrow_forward_ios,
-                                      size: 14, color: Colors.black54),
-                                ),
-                              ],
-                            ),
-                          ],
-                        ),
-                      ),
-                      Container(
-                        // 두 번째 위젯 박스
-                        width: 216,
-                        padding: const EdgeInsets.all(20.0),
-                        margin: const EdgeInsets.only(right: 9.0),
-                        decoration: BoxDecoration(
-                          color: const Color(0xFFDBE7FB),
-                          borderRadius: BorderRadius.circular(15.0),
-                          border: Border.all(
-                            color: const Color(0xFF2B72E7).withOpacity(0.25),
-                            width: 1,
+                                  const SizedBox(width: 9),
+                                ],
+                              );
+                            },
                           ),
-                        ),
-                        child: const Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Text(
-                              '졸업 이수학점 확인 공지',
-                              style: TextStyle(
-                                color: Colors.black,
-                                fontSize: 14,
-                                fontWeight: FontWeight.bold,
-                              ),
-                            ),
-                            Text(
-                              '학생분들은 이수학점 및 현수강',
-                              style: TextStyle(
-                                color: Colors.black54,
-                                fontSize: 12,
-                              ),
-                            ),
-                            SizedBox(height: 29),
-                            Row(
-                              children: [
-                                Text(
-                                  '더보기',
-                                  style: TextStyle(
-                                    color: Colors.black54,
-                                    fontSize: 12,
-                                    fontWeight: FontWeight.bold,
-                                  ),
-                                ),
-                                Padding(
-                                  padding: EdgeInsets.only(right: 30.0),
-                                  child: Icon(Icons.arrow_forward_ios,
-                                      size: 14, color: Colors.black54),
-                                ),
-                              ],
-                            ),
-                          ],
-                        ),
-                      ),
-                    ],
-                  ),
+                        );
+                      } else {
+                        return Container();
+                      }
+                    } else {
+                      return Container();
+                    }
+                  },
                 ),
 
                 const SizedBox(height: 10),
@@ -723,5 +757,9 @@ class _HomePageState extends State<HomePage> {
         ),
       ),
     );
+  }
+
+  Future<List<Map<String, dynamic>>> getData() async {
+    return Provider.of<AnnouncementProvider>(context, listen: false).boardList;
   }
 }

--- a/frontend/lib/screens/myOwnerPage_screen.dart
+++ b/frontend/lib/screens/myOwnerPage_screen.dart
@@ -249,6 +249,7 @@ class _MyOwnerPageState extends State<MyOwnerPage> {
                                   MaterialPageRoute(
                                     builder: (context) => BoardDetailPage(
                                       announcementId: selectedBoard['id'],
+                                      category: 'PROFILE',
                                     ),
                                   ),
                                 );
@@ -273,7 +274,7 @@ class _MyOwnerPageState extends State<MyOwnerPage> {
             ),
           ),
           const Padding(
-            padding: EdgeInsets.symmetric(horizontal: 20.0, vertical: 10.0),
+            padding: EdgeInsets.all(20.0),
             child: AccountWidget(),
           ),
         ],

--- a/frontend/lib/screens/myUserPage_screen.dart
+++ b/frontend/lib/screens/myUserPage_screen.dart
@@ -170,187 +170,198 @@ class _MyUserPageState extends State<MyUserPage> {
           ),
         ],
       ),
-      body: SingleChildScrollView(
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 20.0, vertical: 26.0),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              // 프로필
-              GestureDetector(
-                onTap: () {
-                  Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                      builder: (context) => UserInfoPage(
-                        profile: techStack,
-                      ),
-                    ),
-                  );
-                },
-                child: Profile(
-                  profileUrl: 'assets/images/profile.png',
-                  name: '${techStack['memberName']}', // 이름 전달
-                  status: status ?? '', // 상태 전달
-                  showSubTitle: true,
-                  showExperienceButton: true, // 내 경험 보러가기 버튼 표시 여부
-                  studentId: studentId ?? '', // 학번 전달
-                ),
-              ),
-              const SizedBox(height: 25),
-              const Text(
-                'DEVELOPMENT FIELD',
-                style: TextStyle(
-                  fontSize: 18,
-                  fontWeight: FontWeight.bold,
-                ),
-              ),
-              const SizedBox(height: 20),
-              // Development Field 배지
-              // Wrap : 자식 위젯을 하나씩 순차적으로 채워가면서 너비를 초과하면 자동으로 다음 줄에 이어서 위젯을 채워주는 위젯
-              Wrap(
-                direction: Axis.horizontal,
-                alignment: WrapAlignment.start,
-                spacing: 10,
-                runSpacing: 10,
-                // children 속성에 직접 전달하여 Iterable<Widget> 반환 문제 해결
-                children: developmentField.map((field) {
-                  // 괄호 안에 있는 변수는 리스트를 map한 이름
-                  return badge(
-                    field['logoUrl'],
-                    field['title'],
-                    field['titleColor'],
-                    field['badgeColor'],
-                  );
-                }).toList(),
-              ),
-              const SizedBox(height: 26),
-              const Text(
-                'DEVELOPMENT TOOLS',
-                style: TextStyle(
-                  fontSize: 18,
-                  fontWeight: FontWeight.bold,
-                ),
-              ),
-              const SizedBox(height: 20),
-              // Development Tools 배지
-              Wrap(
-                direction: Axis.horizontal,
-                alignment: WrapAlignment.start,
-                spacing: 10,
-                runSpacing: 10,
-                // children 속성에 직접 전달하여 Iterable<Widget> 반환 문제 해결
-                children: developmentTool.map((tools) {
-                  return badge(
-                    tools['logoUrl'],
-                    tools['title'],
-                    tools['titleColor'],
-                    tools['badgeColor'],
-                  );
-                }).toList(),
-              ),
-              const SizedBox(height: 26),
-              Row(
+      body: Column(
+        children: [
+          SingleChildScrollView(
+            child: Padding(
+              padding:
+                  const EdgeInsets.symmetric(horizontal: 20.0, vertical: 26.0),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
+                  // 프로필
+                  GestureDetector(
+                    onTap: () {
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (context) => UserInfoPage(
+                            profile: techStack,
+                          ),
+                        ),
+                      );
+                    },
+                    child: Profile(
+                      profileUrl: 'assets/images/profile.png',
+                      name: '${techStack['memberName']}', // 이름 전달
+                      status: status ?? '', // 상태 전달
+                      showSubTitle: true,
+                      showExperienceButton: true, // 내 경험 보러가기 버튼 표시 여부
+                      studentId: studentId ?? '', // 학번 전달
+                    ),
+                  ),
+                  const SizedBox(height: 25),
                   const Text(
-                    '내 팀 현황',
+                    'DEVELOPMENT FIELD',
                     style: TextStyle(
                       fontSize: 18,
                       fontWeight: FontWeight.bold,
                     ),
                   ),
-                  IconButton(
-                    onPressed: () {
-                      setState(() {
-                        isExpanded = !isExpanded;
-                      });
-                    },
-                    icon: Icon(
-                      isExpanded ? Icons.expand_less : Icons.expand_more,
+                  const SizedBox(height: 20),
+                  // Development Field 배지
+                  // Wrap : 자식 위젯을 하나씩 순차적으로 채워가면서 너비를 초과하면 자동으로 다음 줄에 이어서 위젯을 채워주는 위젯
+                  Wrap(
+                    direction: Axis.horizontal,
+                    alignment: WrapAlignment.start,
+                    spacing: 10,
+                    runSpacing: 10,
+                    // children 속성에 직접 전달하여 Iterable<Widget> 반환 문제 해결
+                    children: developmentField.map((field) {
+                      // 괄호 안에 있는 변수는 리스트를 map한 이름
+                      return badge(
+                        field['logoUrl'],
+                        field['title'],
+                        field['titleColor'],
+                        field['badgeColor'],
+                      );
+                    }).toList(),
+                  ),
+                  const SizedBox(height: 26),
+                  const Text(
+                    'DEVELOPMENT TOOLS',
+                    style: TextStyle(
+                      fontSize: 18,
+                      fontWeight: FontWeight.bold,
                     ),
                   ),
-                ],
-              ),
-              if (isExpanded)
-                (teamApplyProvider.teams['teamList'] == null ||
-                        teamApplyProvider.teams['teamList'].isEmpty)
-                    ? const Text('생성된 팀이 없습니다.')
-                    : ListView.builder(
-                        shrinkWrap: true,
-                        physics: const NeverScrollableScrollPhysics(),
-                        itemCount: teamApplyProvider.teams['teamList'].length,
-                        itemBuilder: (context, index) {
-                          final team =
-                              teamApplyProvider.teams['teamList'][index];
-                          final teamMembers =
-                              team['teamMember'] as List<dynamic>;
+                  const SizedBox(height: 20),
+                  // Development Tools 배지
+                  Wrap(
+                    direction: Axis.horizontal,
+                    alignment: WrapAlignment.start,
+                    spacing: 10,
+                    runSpacing: 10,
+                    // children 속성에 직접 전달하여 Iterable<Widget> 반환 문제 해결
+                    children: developmentTool.map((tools) {
+                      return badge(
+                        tools['logoUrl'],
+                        tools['title'],
+                        tools['titleColor'],
+                        tools['badgeColor'],
+                      );
+                    }).toList(),
+                  ),
+                  const SizedBox(height: 26),
+                  Row(
+                    children: [
+                      const Text(
+                        '내 팀 현황',
+                        style: TextStyle(
+                          fontSize: 18,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      IconButton(
+                        onPressed: () {
+                          setState(() {
+                            isExpanded = !isExpanded;
+                          });
+                        },
+                        icon: Icon(
+                          isExpanded ? Icons.expand_less : Icons.expand_more,
+                        ),
+                      ),
+                    ],
+                  ),
+                  if (isExpanded)
+                    (teamApplyProvider.teams['teamList'] == null ||
+                            teamApplyProvider.teams['teamList'].isEmpty)
+                        ? const Text('생성된 팀이 없습니다.')
+                        : ListView.builder(
+                            shrinkWrap: true,
+                            physics: const NeverScrollableScrollPhysics(),
+                            itemCount:
+                                teamApplyProvider.teams['teamList'].length,
+                            itemBuilder: (context, index) {
+                              final team =
+                                  teamApplyProvider.teams['teamList'][index];
+                              final teamMembers =
+                                  team['teamMember'] as List<dynamic>;
 
-                          // data의 memberName과 teamMember의 memberName을 비교하여 memberRole을 찾기
-                          final memberRole = teamMembers.firstWhere(
-                            (member) =>
-                                member['memberName'] == techStack['memberName'],
-                            orElse: () => {'memberRole': 'Member'},
-                          )['memberRole'];
+                              // data의 memberName과 teamMember의 memberName을 비교하여 memberRole을 찾기
+                              final memberRole = teamMembers.firstWhere(
+                                (member) =>
+                                    member['memberName'] ==
+                                    techStack['memberName'],
+                                orElse: () => {'memberRole': 'Member'},
+                              )['memberRole'];
 
-                          return Card(
-                            color: const Color(0xFFECECEC),
-                            elevation: 1.0,
-                            child: Padding(
-                              padding: const EdgeInsets.only(top: 5.0),
-                              child: ListTile(
-                                title: Text(
-                                  team['teamName'] ?? '팀 이름 없음',
-                                  style: const TextStyle(
-                                    fontSize: 18,
-                                    fontWeight: FontWeight.bold,
+                              return Card(
+                                color: const Color(0xFFECECEC),
+                                elevation: 1.0,
+                                child: Padding(
+                                  padding: const EdgeInsets.only(top: 5.0),
+                                  child: ListTile(
+                                    title: Text(
+                                      team['teamName'] ?? '팀 이름 없음',
+                                      style: const TextStyle(
+                                        fontSize: 18,
+                                        fontWeight: FontWeight.bold,
+                                      ),
+                                    ),
+                                    subtitle: Row(
+                                      children: [
+                                        Text(
+                                          team['teamCategory'] ?? '카테고리 없음',
+                                          style: const TextStyle(
+                                            fontSize: 14,
+                                            color: Color(0xFF808080),
+                                          ),
+                                        ),
+                                        const SizedBox(width: 14),
+                                        ElevatedButton(
+                                          onPressed: () {},
+                                          style: ElevatedButton.styleFrom(
+                                            backgroundColor:
+                                                const Color(0xFFEA4E44),
+                                            shape: RoundedRectangleBorder(
+                                              borderRadius:
+                                                  BorderRadius.circular(6),
+                                            ),
+                                            minimumSize: const Size(33, 20),
+                                          ),
+                                          child: Text(
+                                            memberRole == 'LEADER'
+                                                ? 'Leader'
+                                                : 'Member',
+                                            style: const TextStyle(
+                                              fontSize: 12,
+                                              fontWeight: FontWeight.bold,
+                                              color: Colors.white,
+                                            ),
+                                          ),
+                                        ),
+                                      ],
+                                    ),
                                   ),
                                 ),
-                                subtitle: Row(
-                                  children: [
-                                    Text(
-                                      team['teamCategory'] ?? '카테고리 없음',
-                                      style: const TextStyle(
-                                        fontSize: 14,
-                                        color: Color(0xFF808080),
-                                      ),
-                                    ),
-                                    const SizedBox(width: 14),
-                                    ElevatedButton(
-                                      onPressed: () {},
-                                      style: ElevatedButton.styleFrom(
-                                        backgroundColor:
-                                            const Color(0xFFEA4E44),
-                                        shape: RoundedRectangleBorder(
-                                          borderRadius:
-                                              BorderRadius.circular(6),
-                                        ),
-                                        minimumSize: const Size(33, 20),
-                                      ),
-                                      child: Text(
-                                        memberRole == 'LEADER'
-                                            ? 'Leader'
-                                            : 'Member',
-                                        style: const TextStyle(
-                                          fontSize: 12,
-                                          fontWeight: FontWeight.bold,
-                                          color: Colors.white,
-                                        ),
-                                      ),
-                                    ),
-                                  ],
-                                ),
-                              ),
-                            ),
-                          );
-                        },
-                      ),
-
-              const SizedBox(height: 20),
-              // 계정(비밀번호 변경, 로그아웃) 위젯
-              const AccountWidget(),
-            ],
+                              );
+                            },
+                          ),
+                ],
+              ),
+            ),
           ),
-        ),
+          // 하단에 고정하고자 하는 위젯을 호출하기 전에 spacer() 위젯 호출
+          const Spacer(),
+
+          // 계정(비밀번호 변경, 로그아웃) 위젯
+          const Padding(
+            padding: EdgeInsets.all(20),
+            child: AccountWidget(),
+          ),
+        ],
       ),
     );
   }

--- a/frontend/lib/widgets/board_widget.dart
+++ b/frontend/lib/widgets/board_widget.dart
@@ -99,16 +99,6 @@ class _BoardState extends State<Board> {
         final category = _getCategoryName(board['announcementCategory']);
         // final isSelected = selectedBoardIndex == index; // 현재 게시글이 선택된 게시글인지 확인
 
-        // 제목이 20자 이상일 때 "..." 처리
-        String truncatedTitle = board['announcementTitle'].length > 20
-            ? '${board['announcementTitle'].substring(0, 20)}...'
-            : board['announcementTitle'];
-
-        // 내용이 30자 이상일 때 "..." 처리
-        String truncatedContent = board['announcementContent'].length > 30
-            ? '${board['announcementContent'].substring(0, 30)}...'
-            : board['announcementContent'];
-
         return Column(
           children: [
             GestureDetector(
@@ -164,35 +154,42 @@ class _BoardState extends State<Board> {
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       Row(
-                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
                         children: [
-                          Row(
-                            children: [
-                              Text(
-                                truncatedTitle,
+                          // Flexible 위젯을 사용하는 이유는 제목 옆에 카테고리가 붙어있어야 하기 때문
+                          Flexible(
+                            child: RichText(
+                              overflow: TextOverflow.ellipsis,
+                              text: TextSpan(
+                                text: board['announcementTitle'],
                                 style: const TextStyle(
                                   fontSize: 16,
                                   fontWeight: FontWeight.bold,
+                                  color: Colors.black,
                                 ),
                               ),
-                              const SizedBox(width: 5),
-                              Text(
-                                category,
-                                style: const TextStyle(
-                                  fontSize: 10,
-                                  color: Color(0xFF7D7D7F),
-                                ),
-                              ),
-                            ],
+                            ),
+                          ),
+                          const SizedBox(width: 5),
+                          Text(
+                            category,
+                            style: const TextStyle(
+                              fontSize: 10,
+                              color: Color(0xFF7D7D7F),
+                            ),
                           ),
                         ],
                       ),
                       const SizedBox(height: 7),
-                      Text(
-                        truncatedContent,
-                        style: const TextStyle(
-                          fontWeight: FontWeight.bold,
-                          fontSize: 14,
+                      RichText(
+                        overflow: TextOverflow.ellipsis,
+                        maxLines: 3,
+                        text: TextSpan(
+                          text: board['announcementContent'],
+                          style: const TextStyle(
+                            fontWeight: FontWeight.bold,
+                            fontSize: 14,
+                            color: Colors.black,
+                          ),
                         ),
                       ),
                       const SizedBox(height: 7),


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
#186

## ✨ 코드 변경 내용
<!-- 코드 변경에 대한 설명을 적어주세요 -->
### 필독 공지를 홈화면에 띄우는 작업 완료
- FutureBuilder를 사용해서 비동기로 공지를 띄움
- 어드민일 경우 important가 true일 때만 필터링
- 유저일 경우 멤버 학년과 공지 학년이 동일한 것까지 포함해서 필터링
- 작성된 공지가 없을 경우 container() 위젯을 통해 필독 공지 자리 공간을 제거
### 홈화면에서 상세페이지로 이동 구현
- category에 HOME을 넣고 전달해 이전페이지로 이동할 수 있게 구현
### 공지글 제목, 내용 오버플로우 기능 구현
- richText 위젯을 사용해서 글 제목이나 내용이 컨테이너 크기를 초과하면 ellipsis 혹은 clip 속성 사용
- 프로필페이지에서 계정 위젯을 화면 화단에 고정 

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->
### 홈화면
![Screenshot_1726493874](https://github.com/user-attachments/assets/044d599a-70e8-4f7b-8196-c546d6c5bed2)

### 프로필 화면
![Screenshot_1726493861](https://github.com/user-attachments/assets/2518e3d6-bc51-4e5c-9a66-c1417b28505b)

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
RichText()