### PR TITLE
[Fix/#208] 회원 새 등록 시 다른 사람의 프로필이 띄워지는 오류 수정

### DIFF
--- a/frontend/lib/screens/login_screen.dart
+++ b/frontend/lib/screens/login_screen.dart
@@ -396,6 +396,11 @@ class _LoginPageState extends State<LoginPage> {
                           // techStack 값이 null이거나 값이 비어있는 경우
                           if (result['techStack'] == null ||
                               result['techStack'].isEmpty) {
+                            // 학번, 비밀번호, fcmToken 저장
+                            await prefs.setString('studentId', studentId);
+                            await prefs.setString('password', password);
+                            await prefs.setString('fcmToken', fcmToken);
+
                             if (context.mounted) {
                               Navigator.pushNamed(context, '/set-profile');
                             }
@@ -403,6 +408,10 @@ class _LoginPageState extends State<LoginPage> {
                             // memberExperience 값이 null이거나 값이 비어있는 경우
                           } else if (result['memberExperiences'] == null ||
                               result['memberExperiences'].isEmpty) {
+                            // 학번, 비밀번호, fcmToken 저장
+                            await prefs.setString('studentId', studentId);
+                            await prefs.setString('password', password);
+                            await prefs.setString('fcmToken', fcmToken);
                             if (context.mounted) {
                               Navigator.pushNamed(
                                   context, '/member-experience');
@@ -413,6 +422,10 @@ class _LoginPageState extends State<LoginPage> {
                                   result['techStack'].isEmpty) &&
                               (result['memberExperiences'] == null ||
                                   result['memberExperiences'].isEmpty)) {
+                            // 학번, 비밀번호, fcmToken 저장
+                            await prefs.setString('studentId', studentId);
+                            await prefs.setString('password', password);
+                            await prefs.setString('fcmToken', fcmToken);
                             if (context.mounted) {
                               Navigator.pushNamed(context, '/set-profile');
                             }

--- a/frontend/lib/screens/setExperience_screen.dart
+++ b/frontend/lib/screens/setExperience_screen.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
+import 'package:frontend/services/login_services.dart';
 import 'package:provider/provider.dart';
 import 'package:frontend/screens/home_screen.dart';
 import 'package:percent_indicator/linear_percent_indicator.dart';
 import 'package:frontend/models/projectExperience_model.dart';
 import 'package:frontend/providers/projectExperience_provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 class SetExperiencePage extends StatefulWidget {
   const SetExperiencePage({super.key});
@@ -105,12 +107,22 @@ class _SetExperiencePageState extends State<SetExperiencePage> {
 
       // 홈 페이지로 이동
       if (context.mounted) {
-        Navigator.push(
-          context,
-          MaterialPageRoute(
-            builder: (context) => const HomePage(),
-          ),
-        );
+        // 아이디, 비밀번호, fcmToken 꺼내옴
+        // 이유 : 로그인 api를 호출해 본인 프로필 정보가 뜰 수 있게 구현(로그인을 호출하지 않으면 전에 로그인한 회원의 정보가 뜸)
+        final prefs = await SharedPreferences.getInstance();
+        final studentId = prefs.getString('studentId');
+        final password = prefs.getString('password');
+        final fcmToken = prefs.getString('fcmToken');
+
+        if (context.mounted) {
+          LoginAPI().handleLogin(context, studentId!, password!, fcmToken!);
+          Navigator.push(
+            context,
+            MaterialPageRoute(
+              builder: (context) => const HomePage(),
+            ),
+          );
+        }
       }
     } else {
       print('입력 사항을 모두 작성해주세요.');


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
#208

## ✨ 코드 변경 내용
<!-- 코드 변경에 대한 설명을 적어주세요 -->
### 처음 등록 시 본인 프로필이 뜨게 구현
- 로그인에서 학번, 비번, 토큰을 저장한 후 경험 생성 후 로그인 호출
- 로그인 파라미터에 저장했던 학번, 비번, 토큰을 꺼내서 집어넣음

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->
https://github.com/user-attachments/assets/d343b2fc-4a2d-4d54-8532-8733fb7fe329

<img width="484" alt="스크린샷 2024-09-26 오전 12 40 19" src="https://github.com/user-attachments/assets/1ba1e23d-4029-48b5-9af1-ad6b193c5816">


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
