### PR TITLE
[Feat/#212] 기능 구현

### DIFF
--- a/frontend/lib/admin/screens/userInfo_screen.dart
+++ b/frontend/lib/admin/screens/userInfo_screen.dart
@@ -24,6 +24,7 @@ class _UserInfoPageState extends State<UserInfoPage> {
   bool selectAll = false; // 전체 삭제 선택 상태 불리안
   List<bool> selectedMembers = []; // 각 아이템의 삭제할 선택 불리안을 저장 리스트
   List<String> selectedStudentIds = [];
+  List<bool> isAscending = [true, true, true, true]; // 순서 상태 리스트
 
   bool isAscendingName = true; // 이름 정렬 순서 상태
   bool isAscendingStudentId = true; // 학번 정렬 순서 상태
@@ -250,6 +251,87 @@ class _UserInfoPageState extends State<UserInfoPage> {
     );
   }
 
+  // 이름, 학번, 학년, 학적상태 필터링 메서드
+  void _sortData(int i) {
+    // 이름 필터링
+    if (i == 0) {
+      if (searchController.text.isEmpty) {
+        // 검색하지 않았을 때는 userList(전체 사용자)로 필터링
+        (isAscending[i] == true)
+            ? userList!.then((userListData) {
+                userListData.sort((a, b) => b.name.compareTo(a.name));
+              })
+            : userList!.then((userListData) {
+                userListData.sort((a, b) => a.name.compareTo(b.name));
+              });
+        // 검색했을 때는 filteredUserList(검색 결과)로 필터링
+      } else {
+        (isAscending[i] == true)
+            ? filteredUserList.sort((a, b) => b.name.compareTo(a.name))
+            : filteredUserList.sort((a, b) => a.name.compareTo(b.name));
+      }
+    }
+
+    // 학번 필터링
+    else if (i == 1) {
+      if (searchController.text.isEmpty) {
+        // 검색하지 않았을 때는 userList(전체 사용자)로 필터링
+        (isAscending[i] == true)
+            ? userList!.then((userListData) {
+                userListData.sort((a, b) => b.studentId.compareTo(a.studentId));
+              })
+            : userList!.then((userListData) {
+                userListData.sort((a, b) => a.studentId.compareTo(b.studentId));
+              });
+        // 검색했을 때는 filteredUserList(검색 결과)로 필터링
+      } else {
+        (isAscending[i] == true)
+            ? filteredUserList
+                .sort((a, b) => b.studentId.compareTo(a.studentId))
+            : filteredUserList
+                .sort((a, b) => a.studentId.compareTo(b.studentId));
+      }
+    }
+
+    // 학년 필터링
+    else if (i == 2) {
+      if (searchController.text.isEmpty) {
+        // 검색하지 않았을 때는 userList(전체 사용자)로 필터링
+        (isAscending[i] == true)
+            ? userList!.then((userListData) {
+                userListData.sort((a, b) => b.level.compareTo(a.level));
+              })
+            : userList!.then((userListData) {
+                userListData.sort((a, b) => a.level.compareTo(b.level));
+              });
+        // 검색했을 때는 filteredUserList(검색 결과)로 필터링
+      } else {
+        (isAscending[i] == true)
+            ? filteredUserList.sort((a, b) => b.level.compareTo(a.level))
+            : filteredUserList.sort((a, b) => a.level.compareTo(b.level));
+      }
+    }
+
+    // 학적상태 필터링
+    else if (i == 3) {
+      if (searchController.text.isEmpty) {
+        // 검색하지 않았을 때는 userList(전체 사용자)로 필터링
+        (isAscending[i] == true)
+            ? userList!.then((userListData) {
+                userListData.sort((a, b) => b.status.compareTo(a.status));
+              })
+            : userList!.then((userListData) {
+                userListData.sort((a, b) => a.status.compareTo(b.status));
+              });
+        // 검색했을 때는 filteredUserList(검색 결과)로 필터링
+      } else {
+        (isAscending[i] == true)
+            ? filteredUserList.sort((a, b) => b.status.compareTo(a.status))
+            : filteredUserList.sort((a, b) => a.status.compareTo(b.status));
+      }
+    }
+  }
+
   // 학년 체크박스 상태
   List<bool> chosenGrades = [false, false, false, false];
 
@@ -454,11 +536,15 @@ class _UserInfoPageState extends State<UserInfoPage> {
                     }
                     return Expanded(
                       child: SingleChildScrollView(
-                        scrollDirection: Axis.horizontal,
-                        child: SingleChildScrollView(
-                          scrollDirection: Axis.vertical,
-                          child: SizedBox(
-                            width: MediaQuery.of(context).size.width,
+                        scrollDirection: Axis.horizontal, // 수평 스크롤
+                        child: ConstrainedBox(
+                          constraints: BoxConstraints(
+                            minWidth: MediaQuery.of(context)
+                                .size
+                                .width, // DataTable이 최소한 화면 크기만큼 확장되도록 설정
+                          ),
+                          child: SingleChildScrollView(
+                            scrollDirection: Axis.vertical, // 수직 스크롤
                             child: DataTable(
                               columnSpacing: 12,
                               horizontalMargin: 12,
@@ -499,10 +585,10 @@ class _UserInfoPageState extends State<UserInfoPage> {
                                     ),
                                   ), // 중앙 정렬
                                 ),
-                                dataColumn('이름', isAscendingName),
-                                dataColumn('학번', isAscendingStudentId),
-                                dataColumn('학년', isAscendingGrade),
-                                dataColumn('학적상태', isAscendingStatus),
+                                dataColumn('이름', 0),
+                                dataColumn('학번', 1),
+                                dataColumn('학년', 2),
+                                dataColumn('학적상태', 3),
                                 const DataColumn(
                                   label: Text('정보 수정'),
                                 ),
@@ -840,19 +926,26 @@ class _UserInfoPageState extends State<UserInfoPage> {
   // 데이터 열
   DataColumn dataColumn(
     String label,
-    bool isAscending,
+    int i,
   ) {
     return DataColumn(
       label: Row(
         children: [
           Text(label),
           IconButton(
+            onPressed: () {
+              setState(() {
+                isAscending[i] = !isAscending[i];
+
+                // 열 데이터 필터링 메서드
+                _sortData(i);
+              });
+            },
             visualDensity: VisualDensity.compact,
             icon: Icon(
-              isAscending ? Icons.arrow_downward : Icons.arrow_upward,
+              isAscending[i] ? Icons.arrow_downward : Icons.arrow_upward,
               size: 16,
             ),
-            onPressed: () {},
           ),
         ],
       ),

--- a/frontend/lib/screens/boardDetail_screen.dart
+++ b/frontend/lib/screens/boardDetail_screen.dart
@@ -1,8 +1,10 @@
 import 'dart:io';
+import 'dart:math';
 import 'dart:typed_data';
 import 'dart:convert';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:frontend/screens/downloadImage_screen.dart';
 import 'package:frontend/screens/update_screen.dart';
 import 'package:frontend/models/vote_model.dart';
 import 'package:frontend/providers/announcement_provider.dart';
@@ -286,19 +288,49 @@ class _BoardDetailPageState extends State<BoardDetailPage> {
                         scrollDirection: Axis.horizontal,
                         child: Row(
                           children: pickedImages.asMap().entries.map((entry) {
+                            int index = entry.key + 1;
                             File imageFile = entry.value;
+
                             return Row(
                               children: [
-                                Center(
-                                  child: Image.file(
-                                    imageFile,
-                                    width: MediaQuery.of(context).size.width,
-                                    fit: BoxFit.cover, // 이미지를 컨테이너에 맞게 채움
-                                    errorBuilder: (BuildContext context,
-                                        Object exception,
-                                        StackTrace? stackTrace) {
-                                      return const Text('이미지를 불러올 수 없습니다.');
-                                    },
+                                GestureDetector(
+                                  onTap: () {
+                                    final imageUrl =
+                                        board['images'][entry.key]['imageUrl'];
+                                    final imageName =
+                                        board['images'][entry.key]['imageName'];
+
+                                    print('imageUrl: $imageUrl');
+                                    print('imageName: $imageName');
+
+                                    Navigator.push(
+                                      context,
+                                      MaterialPageRoute(
+                                        builder: (context) => DownloadImagePage(
+                                          imageFile: imageFile,
+                                          imageLength: pickedImages.length,
+                                          index: index,
+                                          imageUrl: imageUrl,
+                                          imageName: imageName,
+                                        ),
+                                      ),
+                                    );
+                                  },
+                                  child: Center(
+                                    child: Hero(
+                                      tag: 'image_$index',
+                                      child: Image.file(
+                                        imageFile,
+                                        width:
+                                            MediaQuery.of(context).size.width,
+                                        fit: BoxFit.contain, // 이미지를 컨테이너에 맞게 채움
+                                        errorBuilder: (BuildContext context,
+                                            Object exception,
+                                            StackTrace? stackTrace) {
+                                          return const Text('이미지를 불러올 수 없습니다.');
+                                        },
+                                      ),
+                                    ),
                                   ),
                                 ),
                                 const SizedBox(width: 10),
@@ -340,7 +372,7 @@ class _BoardDetailPageState extends State<BoardDetailPage> {
                                           listen: false);
 
                                   await announcementProvider.downloadFile(
-                                      fileUrl, fileName);
+                                      fileUrl, fileName, 'file');
                                 } else {
                                   print('해당 파일 정보를 찾을 수 없습니다.');
                                 }
@@ -365,44 +397,6 @@ class _BoardDetailPageState extends State<BoardDetailPage> {
                         ),
                       ),
 
-                    const SizedBox(height: 20),
-
-                    // Row(
-                    //   crossAxisAlignment: CrossAxisAlignment.center,
-                    //   mainAxisAlignment: MainAxisAlignment.start,
-                    //   children: [
-                    //     GestureDetector(
-                    //       onTap: () async {
-                    //         try {
-                    //           bool suucess =
-                    //               await RecommendProvider().recommend(board['id']);
-                    //           if (suucess) {
-                    //             setState(() {
-                    //               isLiked = !isLiked;
-                    //               likeCount += 1;
-                    //             });
-                    //           }
-                    //         } catch (e) {
-                    //           print(e.toString());
-                    //         }
-                    //       },
-                    //       child: Icon(
-                    //         isLiked ? Icons.favorite : Icons.favorite_border,
-                    //         color: isLiked ? Colors.red : Colors.grey,
-                    //         size: 20,
-                    //       ),
-                    //     ),
-                    //     const SizedBox(width: 2),
-                    //     Text(
-                    //       '$likeCount',
-                    //       style: const TextStyle(
-                    //         fontSize: 14,
-                    //         fontWeight: FontWeight.bold,
-                    //         color: Colors.black,
-                    //       ),
-                    //     ),
-                    //   ],
-                    // ),
                     const SizedBox(height: 20),
 
                     // 투표 보기

--- a/frontend/lib/screens/downloadImage_screen.dart
+++ b/frontend/lib/screens/downloadImage_screen.dart
@@ -1,0 +1,67 @@
+import 'dart:io';
+import 'package:flutter/material.dart';
+
+class DownloadImagePage extends StatelessWidget {
+  final File imageFile;
+  final int imageLength;
+  final int index;
+  final String imageUrl;
+  final String imageName;
+  const DownloadImagePage(
+      {required this.imageFile,
+      required this.imageLength,
+      required this.index,
+      required this.imageUrl,
+      required this.imageName,
+      super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.black,
+      appBar: AppBar(
+        backgroundColor: Colors.black,
+        leading: const BackButton(
+          color: Colors.white,
+        ),
+        title: Text(
+          '$index/$imageLength',
+          style: const TextStyle(
+            color: Colors.white,
+          ),
+        ),
+        actions: const [
+          // IconButton(
+          //   onPressed: () async {
+
+          //     final announcementProvider =
+          //         Provider.of<AnnouncementProvider>(context, listen: false);
+
+          //     await announcementProvider.downloadFile(
+          //         imageUrl, imageName, 'image');
+          //   },
+          //   icon: const Icon(
+          //     Icons.download_sharp,
+          //     color: Colors.white,
+          //   ),
+          // ),
+        ],
+      ),
+      body: Padding(
+        padding: const EdgeInsets.only(top: 60.0),
+        child: Hero(
+          tag: 'image_$index',
+          child: Image.file(
+            imageFile,
+            width: MediaQuery.of(context).size.width,
+            fit: BoxFit.cover, // 이미지를 컨테이너에 맞게 채움
+            errorBuilder: (BuildContext context, Object exception,
+                StackTrace? stackTrace) {
+              return const Text('이미지를 불러올 수 없습니다.');
+            },
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/lib/screens/home_screen.dart
+++ b/frontend/lib/screens/home_screen.dart
@@ -69,8 +69,7 @@ class _HomePageState extends State<HomePage> {
     },
   ];
 
-  List<Map<String, dynamic>> userBoardList =
-      []; // 학생에게 보여질 공지글(해당 학년의 공지글만 보여주기 위해)
+  Future<List<Map<String, dynamic>>>? boardList;
 
   // 위젯의 상태 초기화
   @override
@@ -84,7 +83,10 @@ class _HomePageState extends State<HomePage> {
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       await Provider.of<AnnouncementProvider>(context, listen: false)
           .fetchAllBoards();
-      getData(); // 전체 공지 api가 먼저 호출되어야 홈화면에 공지를 띄울 수 있음.
+
+      setState(() {
+        boardList = getData();
+      });
     });
 
     _loadCredentials();
@@ -107,7 +109,7 @@ class _HomePageState extends State<HomePage> {
 
     FirebaseMessaging.onMessageOpenedApp.listen((RemoteMessage message) {
       setState(() {
-        notificationCount = 0; // 사용자가 앱을 열면 카운트를 초기화
+        notificationCount += 1; // 앱이 열릴 때도 알림 카운트 증가
       });
     });
   }
@@ -231,15 +233,6 @@ class _HomePageState extends State<HomePage> {
     }
   }
 
-  // 알림 버튼 누를 시  FCM 토큰 발급 함수
-  Future<String> _getFCMToken() async {
-    FirebaseMessaging messaging = FirebaseMessaging.instance;
-    String? token = await messaging.getToken();
-    // print('FCM 토큰: $token');
-
-    return token!;
-  }
-
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
@@ -316,6 +309,8 @@ class _HomePageState extends State<HomePage> {
               padding: const EdgeInsets.only(right: 20.0),
               child: GestureDetector(
                 onTap: () async {
+                  print('알림 수: $notificationCount');
+
                   if (userRole == 'ROLE_USER') {
                     if (context.mounted) {
                       Navigator.pushNamed(
@@ -360,7 +355,7 @@ class _HomePageState extends State<HomePage> {
 
                 // 필독 공지들
                 FutureBuilder<List<Map<String, dynamic>>>(
-                  future: getData(),
+                  future: boardList,
                   builder: (context, snapshot) {
                     if (snapshot.connectionState == ConnectionState.waiting) {
                       return const Center(
@@ -373,11 +368,14 @@ class _HomePageState extends State<HomePage> {
                     } else if (snapshot.hasData && snapshot.data!.isNotEmpty) {
                       List<Map<String, dynamic>> boardList = snapshot.data!;
 
+                      List<Map<String, dynamic>> userBoardList =
+                          []; // 학생에게 보여질 공지글(해당 학년의 공지글만 보여주기 위해)
+                      List<Map<String, dynamic>> mustBoardList = [];
+
                       // 전체 공지에서 필독 상태인 공지만 필터링한 공지
-                      List<Map<String, dynamic>> mustBoardList =
-                          boardList.where((board) {
-                        return board['announcementImportant'] == true;
-                      }).toList();
+                      if (userRole == 'ROLE_ADMIN') {
+                        mustBoardList = boardList;
+                      }
 
                       // 학생일 경우에는 학년까지 필터링해야 함
                       if (userRole == 'ROLE_USER') {
@@ -387,115 +385,120 @@ class _HomePageState extends State<HomePage> {
                         }).toList();
                       }
 
-                      // 공지글이 비어있으면 공지 아이콘들이 최상단에 위치
-                      if (userBoardList.isNotEmpty ||
-                          mustBoardList.isNotEmpty) {
-                        return SizedBox(
-                          height: MediaQuery.of(context).size.height / 6,
-                          child: ListView.builder(
-                            scrollDirection: Axis.horizontal,
-                            itemCount: (userRole == 'ROLE_USER')
-                                ? userBoardList.length
-                                : mustBoardList.length,
-                            shrinkWrap: true, // 높이를 제한하는 데 도움을 줌
-                            itemBuilder: (context, index) {
-                              final board = (userRole == 'ROLE_USER')
-                                  ? userBoardList[index]
-                                  : mustBoardList[index];
+                      return (userBoardList.isNotEmpty ||
+                              mustBoardList.isNotEmpty)
+                          ? SizedBox(
+                              height: MediaQuery.of(context).size.height / 6,
+                              child: ListView.builder(
+                                scrollDirection: Axis.horizontal,
+                                itemCount: (userRole == 'ROLE_USER')
+                                    ? userBoardList.length
+                                    : mustBoardList.length,
+                                shrinkWrap: true, // 높이를 제한하는 데 도움을 줌
+                                itemBuilder: (context, index) {
+                                  final board = (userRole == 'ROLE_USER')
+                                      ? userBoardList[index]
+                                      : mustBoardList[index];
 
-                              return Row(
-                                children: [
-                                  GestureDetector(
-                                    onTap: () {
-                                      Navigator.push(
-                                        context,
-                                        MaterialPageRoute(
-                                          builder: (context) => BoardDetailPage(
-                                            announcementId: board['id'],
-                                            category: 'HOME',
-                                          ),
-                                        ),
-                                      );
-                                    },
-                                    child: Container(
-                                      width:
-                                          MediaQuery.of(context).size.width / 2,
-                                      padding: const EdgeInsets.all(10.0),
-                                      decoration: BoxDecoration(
-                                        color: const Color(0xFFDBE7FB),
-                                        borderRadius:
-                                            BorderRadius.circular(15.0),
-                                        border: Border.all(
-                                          color: const Color(0xFF2B72E7)
-                                              .withOpacity(0.25),
-                                          width: 1,
-                                        ),
-                                      ),
-                                      child: Column(
-                                        crossAxisAlignment:
-                                            CrossAxisAlignment.start,
-                                        children: [
-                                          // 컨테이너 크기에 맞게 줄임표를 사용하여 텍스트가 오버플로되었음을 나타냄
-                                          // 공지글 제목
-                                          RichText(
-                                            overflow: TextOverflow.ellipsis,
-                                            text: TextSpan(
-                                              text: board['announcementTitle'],
-                                              style: const TextStyle(
-                                                color: Colors.black,
-                                                fontSize: 14,
-                                                fontWeight: FontWeight.bold,
+                                  return Row(
+                                    children: [
+                                      GestureDetector(
+                                        onTap: () {
+                                          Navigator.push(
+                                            context,
+                                            MaterialPageRoute(
+                                              builder: (context) =>
+                                                  BoardDetailPage(
+                                                announcementId: board['id'],
+                                                category: 'HOME',
                                               ),
                                             ),
-                                          ),
-
-                                          // 공지글 내용
-                                          RichText(
-                                            overflow: TextOverflow.ellipsis,
-                                            maxLines: 2,
-                                            text: TextSpan(
-                                              text:
-                                                  board['announcementContent'],
-                                              style: const TextStyle(
-                                                color: Colors.black54,
-                                                fontSize: 12,
-                                              ),
+                                          );
+                                        },
+                                        child: Container(
+                                          width: MediaQuery.of(context)
+                                                  .size
+                                                  .width /
+                                              2,
+                                          padding: const EdgeInsets.all(10.0),
+                                          decoration: BoxDecoration(
+                                            color: const Color(0xFFDBE7FB),
+                                            borderRadius:
+                                                BorderRadius.circular(15.0),
+                                            border: Border.all(
+                                              color: const Color(0xFF2B72E7)
+                                                  .withOpacity(0.25),
+                                              width: 1,
                                             ),
                                           ),
-                                          const SizedBox(height: 29),
-                                          const Row(
+                                          child: Column(
+                                            crossAxisAlignment:
+                                                CrossAxisAlignment.start,
                                             children: [
-                                              Text(
-                                                '더보기',
-                                                style: TextStyle(
-                                                  color: Colors.black54,
-                                                  fontSize: 12,
-                                                  fontWeight: FontWeight.bold,
+                                              // 컨테이너 크기에 맞게 줄임표를 사용하여 텍스트가 오버플로되었음을 나타냄
+                                              // 공지글 제목
+                                              RichText(
+                                                overflow: TextOverflow.ellipsis,
+                                                text: TextSpan(
+                                                  text: board[
+                                                      'announcementTitle'],
+                                                  style: const TextStyle(
+                                                    color: Colors.black,
+                                                    fontSize: 14,
+                                                    fontWeight: FontWeight.bold,
+                                                  ),
                                                 ),
                                               ),
-                                              Padding(
-                                                padding: EdgeInsets.only(
-                                                    right: 30.0),
-                                                child: Icon(
-                                                    Icons.arrow_forward_ios,
-                                                    size: 14,
-                                                    color: Colors.black54),
+
+                                              // 공지글 내용
+                                              RichText(
+                                                overflow: TextOverflow.ellipsis,
+                                                maxLines: 2,
+                                                text: TextSpan(
+                                                  text: board[
+                                                      'announcementContent'],
+                                                  style: const TextStyle(
+                                                    color: Colors.black54,
+                                                    fontSize: 12,
+                                                  ),
+                                                ),
+                                              ),
+                                              const SizedBox(height: 29),
+                                              const Row(
+                                                children: [
+                                                  Text(
+                                                    '더보기',
+                                                    style: TextStyle(
+                                                      color: Colors.black54,
+                                                      fontSize: 12,
+                                                      fontWeight:
+                                                          FontWeight.bold,
+                                                    ),
+                                                  ),
+                                                  Padding(
+                                                    padding: EdgeInsets.only(
+                                                        right: 30.0),
+                                                    child: Icon(
+                                                        Icons.arrow_forward_ios,
+                                                        size: 14,
+                                                        color: Colors.black54),
+                                                  ),
+                                                ],
                                               ),
                                             ],
                                           ),
-                                        ],
+                                        ),
                                       ),
-                                    ),
-                                  ),
-                                  const SizedBox(width: 9),
-                                ],
-                              );
-                            },
-                          ),
-                        );
-                      } else {
-                        return Container();
-                      }
+                                      const SizedBox(width: 9),
+                                    ],
+                                  );
+                                },
+                              ),
+                            )
+                          : const SizedBox(
+                              width: 0,
+                              height: 0,
+                            );
                     } else {
                       return Container();
                     }
@@ -580,121 +583,7 @@ class _HomePageState extends State<HomePage> {
                   ),
                 ),
 
-                // 커뮤니티
-                // const Row(
-                //   mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                //   children: [
-                //     Padding(
-                //       padding: EdgeInsets.only(top: 20),
-                //       child: Text(
-                //         '커뮤니티',
-                //         style: TextStyle(
-                //           fontSize: 20,
-                //           fontWeight: FontWeight.bold,
-                //         ),
-                //       ),
-                //     ),
-                //     Padding(
-                //       padding: EdgeInsets.only(top: 20),
-                //       child: Row(
-                //         children: [
-                //           Text(
-                //             '더보기',
-                //             style: TextStyle(
-                //               color: Colors.black54,
-                //               fontSize: 12,
-                //               fontWeight: FontWeight.bold,
-                //             ),
-                //           ),
-                //           Padding(
-                //             padding: EdgeInsets.only(right: 30.0),
-                //             child: Icon(Icons.arrow_forward_ios,
-                //                 size: 14, color: Colors.black54),
-                //           ),
-                //         ],
-                //       ),
-                //     ),
-                //   ],
-                // ),
-                // Container(
-                //   // 네 번째 위젯 박스
-                //   width: MediaQuery.of(context).size.width,
-                //   padding: const EdgeInsets.all(20.0),
-                //   margin: const EdgeInsets.only(right: 9.0),
-                //   decoration: BoxDecoration(
-                //     color: const Color(0xFFFAFAFE),
-                //     borderRadius: BorderRadius.circular(15.0), // 박스 둥근 비율
-                //   ),
-                //   child: const Column(
-                //     children: [
-                //       Row(
-                //         children: [
-                //           Text(
-                //             '대외 활동',
-                //             style: TextStyle(
-                //               color: Colors.black,
-                //               fontSize: 14,
-                //               fontWeight: FontWeight.normal,
-                //             ),
-                //           ),
-                //           SizedBox(width: 17),
-                //           Text(
-                //             '코테노이아 절찬 모집중!!!',
-                //             style: TextStyle(
-                //               color: Colors.black,
-                //               fontSize: 12,
-                //               fontWeight: FontWeight.normal,
-                //             ),
-                //           ),
-                //         ],
-                //       ),
-                //       SizedBox(height: 16),
-                //       Row(
-                //         children: [
-                //           Text(
-                //             '취업 진로',
-                //             style: TextStyle(
-                //               color: Colors.black,
-                //               fontSize: 14,
-                //               fontWeight: FontWeight.normal,
-                //             ),
-                //           ),
-                //           SizedBox(width: 17),
-                //           Text(
-                //             '이거 꼭 해봐!!',
-                //             style: TextStyle(
-                //               color: Colors.black,
-                //               fontSize: 12,
-                //               fontWeight: FontWeight.normal,
-                //             ),
-                //           ),
-                //         ],
-                //       ),
-                //       SizedBox(height: 16),
-                //       Row(
-                //         children: [
-                //           Text(
-                //             '정통 광장',
-                //             style: TextStyle(
-                //               color: Colors.black,
-                //               fontSize: 14,
-                //               fontWeight: FontWeight.normal,
-                //             ),
-                //           ),
-                //           SizedBox(width: 17),
-                //           Text(
-                //             '시험 범위 알려줄 사람~~',
-                //             style: TextStyle(
-                //               color: Colors.black,
-                //               fontSize: 12,
-                //               fontWeight: FontWeight.normal,
-                //             ),
-                //           ),
-                //         ],
-                //       ),
-                //     ],
-                //   ),
-                // ),
+                // 달력
                 const Padding(
                   padding: EdgeInsets.only(top: 20),
                   child: Text(

--- a/frontend/lib/screens/home_screen.dart
+++ b/frontend/lib/screens/home_screen.dart
@@ -368,6 +368,17 @@ class _HomePageState extends State<HomePage> {
                     } else if (snapshot.hasData && snapshot.data!.isNotEmpty) {
                       List<Map<String, dynamic>> boardList = snapshot.data!;
 
+                      // 게시글을 작성 시간 순서대로 정렬
+                      boardList.sort((a, b) {
+                        DateTime createdTimeA = DateTime.parse(
+                            a['createdTime']); // 작성 시간은 DateTime으로 변환
+                        DateTime createdTimeB =
+                            DateTime.parse(b['createdTime']);
+                        return createdTimeB.compareTo(
+                            createdTimeA); // b가 a보다 더 최근일 경우 양수를 반환(즉, 최신순 정렬)
+                        // 반환값이 양수이면, 순서가 바뀌고 음수이면, 순서가 바뀌지 않음
+                      });
+
                       List<Map<String, dynamic>> userBoardList =
                           []; // 학생에게 보여질 공지글(해당 학년의 공지글만 보여주기 위해)
                       List<Map<String, dynamic>> mustBoardList = [];

--- a/frontend/lib/screens/myOwnerPage_screen.dart
+++ b/frontend/lib/screens/myOwnerPage_screen.dart
@@ -159,6 +159,7 @@ class _MyOwnerPageState extends State<MyOwnerPage> {
           ),
         ),
         leadingWidth: 120, // leading에 있는 위젯 크게 만들기 위한 코드
+        centerTitle: true,
         title: const Text(
           '내 정보',
           style: TextStyle(

--- a/frontend/lib/screens/myUserPage_screen.dart
+++ b/frontend/lib/screens/myUserPage_screen.dart
@@ -133,6 +133,7 @@ class _MyUserPageState extends State<MyUserPage> {
           ),
         ),
         leadingWidth: 120,
+        centerTitle: true,
         title: const Text(
           '내 정보',
           style: TextStyle(

--- a/frontend/lib/screens/totalBoard_screen.dart
+++ b/frontend/lib/screens/totalBoard_screen.dart
@@ -62,7 +62,7 @@ class _TotalBoardPageState extends State<TotalBoardPage> {
       await Provider.of<AnnouncementProvider>(context, listen: false)
           .fetchAllBoards();
 
-      if (context.mounted) {
+      if (mounted) {
         setState(() {
           boardList = Provider.of<AnnouncementProvider>(context, listen: false)
               .boardList;

--- a/frontend/lib/screens/update_screen.dart
+++ b/frontend/lib/screens/update_screen.dart
@@ -281,21 +281,26 @@ class _BoardUpdatePageState extends State<BoardUpdatePage> {
             Navigator.pop(context);
           },
         ),
-        actions: const [
+        actions: [
+          // 프로필 아이콘
           Padding(
-            padding: EdgeInsets.only(right: 23.0),
-            child: Icon(
-              Icons.add_alert,
-              size: 30,
-              color: Colors.black,
-            ),
-          ),
-          Padding(
-            padding: EdgeInsets.only(right: 23.0),
-            child: Icon(
-              Icons.account_circle,
-              size: 30,
-              color: Colors.black,
+            padding: const EdgeInsets.only(right: 23.0),
+            child: IconButton(
+              onPressed: () async {
+                if (context.mounted) {
+                  Navigator.pushNamed(
+                    context,
+                    '/myowner',
+                  );
+                }
+              },
+              padding: EdgeInsets.zero,
+              icon: const Icon(
+                Icons.account_circle,
+                size: 30,
+                color: Colors.black,
+              ),
+              visualDensity: VisualDensity.compact,
             ),
           ),
         ],
@@ -309,7 +314,7 @@ class _BoardUpdatePageState extends State<BoardUpdatePage> {
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
                 SizedBox(
-                  width: 315,
+                  width: MediaQuery.of(context).size.width,
                   child: TextFormField(
                     controller: titleController,
                     focusNode: titleFocusNode,
@@ -329,31 +334,6 @@ class _BoardUpdatePageState extends State<BoardUpdatePage> {
                         titleController.text = val!;
                       });
                     },
-                  ),
-                ),
-
-                // 미리보기
-                Padding(
-                  padding: const EdgeInsets.only(right: 17.0),
-                  child: ElevatedButton(
-                    onPressed: () {
-                      _showPreview(context);
-                    },
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: const Color(0xFFDBE7FB),
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(5.0),
-                      ),
-                      padding: EdgeInsets.zero,
-                      minimumSize: const Size(50, 30),
-                    ),
-                    child: const Text(
-                      '미리보기',
-                      style: TextStyle(
-                        color: Color(0xFF6E747E),
-                        fontSize: 12,
-                      ),
-                    ),
                   ),
                 ),
               ],
@@ -506,15 +486,44 @@ class _BoardUpdatePageState extends State<BoardUpdatePage> {
             const SizedBox(height: 25),
 
             // 설정
-            const Padding(
-              padding: EdgeInsets.symmetric(horizontal: 17.0),
-              child: Text(
-                '설정',
-                style: TextStyle(
-                  fontSize: 20,
-                  fontWeight: FontWeight.bold,
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                const Padding(
+                  padding: EdgeInsets.symmetric(horizontal: 17.0),
+                  child: Text(
+                    '설정',
+                    style: TextStyle(
+                      fontSize: 20,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
                 ),
-              ),
+                // 미리보기
+                Padding(
+                  padding: const EdgeInsets.only(right: 17.0),
+                  child: ElevatedButton(
+                    onPressed: () {
+                      _showPreview(context);
+                    },
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: const Color(0xFFDBE7FB),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(5.0),
+                      ),
+                      padding: EdgeInsets.zero,
+                      minimumSize: const Size(50, 30),
+                    ),
+                    child: const Text(
+                      '미리보기',
+                      style: TextStyle(
+                        color: Color(0xFF6E747E),
+                        fontSize: 12,
+                      ),
+                    ),
+                  ),
+                ),
+              ],
             ),
             const SizedBox(height: 20),
 

--- a/frontend/lib/screens/write_screen.dart
+++ b/frontend/lib/screens/write_screen.dart
@@ -173,64 +173,98 @@ class _BoardWritePageState extends State<BoardWritePage> {
     return Scaffold(
       backgroundColor: Colors.white,
       resizeToAvoidBottomInset: false, // 버튼과 키보드가 겹쳐도 오류가 안나게 하기
-      appBar: const BoardAppbar(),
+      appBar: AppBar(
+        backgroundColor: Colors.white,
+        scrolledUnderElevation: 0, // 스크롤 시 상단바 색상 바뀌는 오류
+        toolbarHeight: 70,
+        leadingWidth: 140,
+        leading: Padding(
+          padding: const EdgeInsets.only(left: 12.0),
+          child: IconButton(
+            onPressed: () {
+              Navigator.pushNamedAndRemoveUntil(
+                  context, '/homepage', (route) => false);
+            },
+            icon: Image.asset('assets/images/logo.png'),
+            color: Colors.black,
+          ),
+        ),
+        actions: [
+          // 미리보기
+          Padding(
+            padding: const EdgeInsets.only(right: 17.0),
+            child: ElevatedButton(
+              onPressed: () {
+                _showPreview(context);
+              },
+              style: ElevatedButton.styleFrom(
+                backgroundColor: const Color(0xFFDBE7FB),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(5.0),
+                ),
+                padding: EdgeInsets.zero,
+                minimumSize: const Size(50, 30),
+              ),
+              child: const Text(
+                '미리보기',
+                style: TextStyle(
+                  color: Color(0xFF6E747E),
+                  fontSize: 12,
+                ),
+              ),
+            ),
+          ),
+
+          // 프로필 아이콘
+          Padding(
+            padding: const EdgeInsets.only(right: 23.0),
+            child: IconButton(
+              onPressed: () async {
+                if (context.mounted) {
+                  Navigator.pushNamed(
+                    context,
+                    '/myowner',
+                  );
+                }
+              },
+              padding: EdgeInsets.zero,
+              icon: const Icon(
+                Icons.account_circle,
+                size: 30,
+                color: Colors.black,
+              ),
+              visualDensity: VisualDensity.compact,
+            ),
+          ),
+        ],
+      ),
       body: SingleChildScrollView(
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             // 제목 입력 필드
-            Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                SizedBox(
-                  width: 315,
-                  child: TextFormField(
-                    controller: titleController,
-                    focusNode: titleFocusNode,
-                    decoration: InputDecoration(
-                      hintText: '제목을 작성해주세요(경진대회 공지일 경우 []안에 대회명을 작성해주세요)',
-                      hintStyle: TextStyle(
-                        color: Colors.black.withOpacity(0.25),
-                      ),
-                      contentPadding: const EdgeInsetsDirectional.symmetric(
-                          horizontal: 10.0),
-                      enabledBorder: const OutlineInputBorder(
-                        borderSide: BorderSide.none,
-                      ),
-                    ),
-                    onSaved: (val) {
-                      setState(() {
-                        titleController.text = val!;
-                      });
-                    },
+            SizedBox(
+              width: MediaQuery.of(context).size.width,
+              child: TextFormField(
+                controller: titleController,
+                focusNode: titleFocusNode,
+                decoration: InputDecoration(
+                  hintText: '제목을 작성해주세요(경진대회 공지일 경우 []안에 대회명을 작성해주세요)',
+                  hintStyle: TextStyle(
+                    color: Colors.black.withOpacity(0.25),
+                  ),
+                  contentPadding:
+                      const EdgeInsetsDirectional.symmetric(horizontal: 10.0),
+                  enabledBorder: const OutlineInputBorder(
+                    borderSide: BorderSide.none,
                   ),
                 ),
-
-                // 미리보기
-                Padding(
-                  padding: const EdgeInsets.only(right: 17.0),
-                  child: ElevatedButton(
-                    onPressed: () {
-                      _showPreview(context);
-                    },
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: const Color(0xFFDBE7FB),
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(5.0),
-                      ),
-                      padding: EdgeInsets.zero,
-                      minimumSize: const Size(50, 30),
-                    ),
-                    child: const Text(
-                      '미리보기',
-                      style: TextStyle(
-                        color: Color(0xFF6E747E),
-                        fontSize: 12,
-                      ),
-                    ),
-                  ),
-                ),
-              ],
+                onSaved: (val) {
+                  setState(() {
+                    titleController.text = val!;
+                  });
+                },
+              ),
             ),
 
             Container(

--- a/frontend/lib/screens/write_screen.dart
+++ b/frontend/lib/screens/write_screen.dart
@@ -6,7 +6,6 @@ import 'package:frontend/providers/announcement_provider.dart';
 import 'package:frontend/models/board_model.dart';
 import 'package:frontend/models/vote_model.dart';
 import 'package:frontend/providers/vote_provider.dart';
-import 'package:frontend/widgets/boardAppbar_widget.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:flutter_datetime_picker_plus/flutter_datetime_picker_plus.dart'
     as picker;
@@ -190,31 +189,6 @@ class _BoardWritePageState extends State<BoardWritePage> {
           ),
         ),
         actions: [
-          // 미리보기
-          Padding(
-            padding: const EdgeInsets.only(right: 17.0),
-            child: ElevatedButton(
-              onPressed: () {
-                _showPreview(context);
-              },
-              style: ElevatedButton.styleFrom(
-                backgroundColor: const Color(0xFFDBE7FB),
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(5.0),
-                ),
-                padding: EdgeInsets.zero,
-                minimumSize: const Size(50, 30),
-              ),
-              child: const Text(
-                '미리보기',
-                style: TextStyle(
-                  color: Color(0xFF6E747E),
-                  fontSize: 12,
-                ),
-              ),
-            ),
-          ),
-
           // 프로필 아이콘
           Padding(
             padding: const EdgeInsets.only(right: 23.0),
@@ -394,15 +368,44 @@ class _BoardWritePageState extends State<BoardWritePage> {
             const SizedBox(height: 25),
 
             // 설정
-            const Padding(
-              padding: EdgeInsets.symmetric(horizontal: 17.0),
-              child: Text(
-                '설정',
-                style: TextStyle(
-                  fontSize: 20,
-                  fontWeight: FontWeight.bold,
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                const Padding(
+                  padding: EdgeInsets.symmetric(horizontal: 17.0),
+                  child: Text(
+                    '설정',
+                    style: TextStyle(
+                      fontSize: 20,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
                 ),
-              ),
+                // 미리보기
+                Padding(
+                  padding: const EdgeInsets.only(right: 17.0),
+                  child: ElevatedButton(
+                    onPressed: () {
+                      _showPreview(context);
+                    },
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: const Color(0xFFDBE7FB),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(5.0),
+                      ),
+                      padding: EdgeInsets.zero,
+                      minimumSize: const Size(50, 30),
+                    ),
+                    child: const Text(
+                      '미리보기',
+                      style: TextStyle(
+                        color: Color(0xFF6E747E),
+                        fontSize: 12,
+                      ),
+                    ),
+                  ),
+                ),
+              ],
             ),
             const SizedBox(height: 20),
 

--- a/frontend/lib/widgets/board_widget.dart
+++ b/frontend/lib/widgets/board_widget.dart
@@ -94,16 +94,25 @@ class _BoardState extends State<Board> {
       );
     }
 
+    // 공지사항을 createdTime으로 정렬 (내림차순으로 최신부터)
+    final sortedBoardList = (widget.total && userRole == 'ROLE_USER')
+        ? filteredBoardList
+        : widget.boardList;
+    sortedBoardList.sort((a, b) {
+      DateTime createdTimeA =
+          DateTime.parse(a['createdTime']); // 작성 시간은 DateTime으로 변환
+      DateTime createdTimeB = DateTime.parse(b['createdTime']);
+      return createdTimeB
+          .compareTo(createdTimeA); // b가 a보다 더 최근일 경우 양수를 반환(즉, 최신순 정렬)
+      // 반환값이 양수이면, 순서가 바뀌고 음수이면, 순서가 바뀌지 않음
+    });
+
     // 필터링된 공지사항 리스트를 화면에 표시
     return ListView.builder(
-      itemCount: (widget.total && userRole == 'ROLE_USER')
-          ? filteredBoardList.length
-          : widget.boardList.length,
+      itemCount: sortedBoardList.length,
       shrinkWrap: true, // 높이를 자동으로 조절
       itemBuilder: (context, index) {
-        final board = (widget.total && userRole == 'ROLE_USER')
-            ? filteredBoardList[index]
-            : widget.boardList[index];
+        final board = sortedBoardList[index];
         final category = _getCategoryName(board['announcementCategory']);
         // final isSelected = selectedBoardIndex == index; // 현재 게시글이 선택된 게시글인지 확인
 
@@ -134,22 +143,24 @@ class _BoardState extends State<Board> {
 
               // 숨김/삭제 버튼 띄울 때
               onLongPress: () async {
-                if (selectedBoardIndex != null) {
-                  setState(() {
-                    selectedBoardIndex = null;
-                  });
-                } else {
-                  setState(() {
-                    selectedBoardIndex = index; // 선택된 게시글의 인덱스를 저장
-                  });
-                }
-                print('selectedBoardIndex: $selectedBoardIndex');
+                if (widget.category == 'HIDDEN') {
+                  if (selectedBoardIndex != null) {
+                    setState(() {
+                      selectedBoardIndex = null;
+                    });
+                  } else {
+                    setState(() {
+                      selectedBoardIndex = index; // 선택된 게시글의 인덱스를 저장
+                    });
+                  }
+                  print('selectedBoardIndex: $selectedBoardIndex');
 
-                if (widget.onBoardSelected != null) {
-                  widget.onBoardSelected!(board); // 선택된 게시글 콜백 호출
-                }
+                  if (widget.onBoardSelected != null) {
+                    widget.onBoardSelected!(board); // 선택된 게시글 콜백 호출
+                  }
 
-                print('selectedBoard: ${board['announcementTitle']}');
+                  print('selectedBoard: ${board['announcementTitle']}');
+                }
               },
               child: Card(
                 color: const Color(0xFFFAFAFE),

--- a/frontend/lib/widgets/vote_widget.dart
+++ b/frontend/lib/widgets/vote_widget.dart
@@ -339,8 +339,8 @@ class _VoteWidgetState extends State<VoteWidget> {
                                               horizontal: 20.0, vertical: 6.0),
                                           width: MediaQuery.of(context)
                                                   .size
-                                                  .width *
-                                              0.2,
+                                                  .width /
+                                              2,
                                           height: 28,
                                           child: Row(
                                             mainAxisAlignment:


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
#212

## ✨ 코드 변경 내용
<!-- 코드 변경에 대한 설명을 적어주세요 -->
### 공지글 작성 순서대로 배열(가장 최근작성이 위로 가게)
- sort 메서드를 사용해서 두 개의 공지사항 시간을 비교하여 순서를 결정
- compareTo 메서드를 이용해서 두 날짜를 비교해 반환값에 따라 순서를 결정
- 양수이면, 순서를 변경하고 음수이면, 순서를 변경하지 않음
### 이미지 전체보기 기능 구현
- Hero 위젯을 사용하여 검은 바탕의 이미지 전체를 볼 수 있는 페이지로 이동
- entry.key와 pickedImages.length를 전달해 몇번째 이미지인지 상단바에 표시
- 혹시 모를 이미지 다운을 위해 url과 파일 이름을 전달한 후 파일 다운 api를 작성
### 사용자 정보(이름 : 한글 순, 학번 : 숫자 순, 학년 : 숫자 순) 정렬
- 이름, 학번, 학년, 학정상태에 숫자를 부여해 숫자마다 if문을 적용
- 정렬방식은 compareTo 메서드를 사용해서 isAscending 값에 따라 내림⋅오름 차순 설정
- 검색하지 않았을 경우에는 전체 리스트로, 검색했을 경우에는 검색 결과 리스트로 정렬 기능 구현
### 투표 항목 너비 늘리기
- 전체 너비의 절반으로 수정
### 홈화면 공지글도 작성 순서대로 정렬

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->
### 공지글 작성시간 순서대로 정렬
![공지글 작성시간대로 정렬](https://github.com/user-attachments/assets/aede511a-88e8-45e4-926d-596a9e8938d4)
### 이미지 전체보기 기능
https://github.com/user-attachments/assets/5f1bdb4b-c4d3-435e-b166-cb4abb2fb66e
### 사용자 순서정렬
https://github.com/user-attachments/assets/6cacbf00-c0e1-47eb-8998-4b55a6a40b3a
### 투표 항목 늘리기
![투표 항목 늘리기](https://github.com/user-attachments/assets/b5cc17d6-422f-46c7-991d-72ef9d4ea6f4)
### 홈화면 공지 작성시간순서대로 정렬
![홈화면 공지글 작성시간 순서대로](https://github.com/user-attachments/assets/c1f537de-91a0-4a1f-87d5-a16c5e54463e)

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->