### PR TITLE
[Fix/#240] 프로필 수정 UI 변경하기

### DIFF
--- a/frontend/lib/screens/editField_screen.dart
+++ b/frontend/lib/screens/editField_screen.dart
@@ -29,7 +29,9 @@ class _EditFieldPageState extends State<EditFieldPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      backgroundColor: Colors.white,
       appBar: AppBar(
+        backgroundColor: Colors.white,
         title: const Text('Development Field 수정'),
       ),
       body: SingleChildScrollView(

--- a/frontend/lib/screens/editTool_screen.dart
+++ b/frontend/lib/screens/editTool_screen.dart
@@ -29,7 +29,9 @@ class _EditToolPageState extends State<EditToolPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      backgroundColor: Colors.white,
       appBar: AppBar(
+        backgroundColor: Colors.white,
         title: const Text('Development Tool 수정'),
       ),
       body: Padding(

--- a/frontend/lib/screens/home_screen.dart
+++ b/frontend/lib/screens/home_screen.dart
@@ -327,13 +327,6 @@ class _HomePageState extends State<HomePage> {
                       );
                     }
                   }
-
-                  // 3초 후 다이얼로그 닫기
-                  Future.delayed(const Duration(seconds: 3), () {
-                    if (context.mounted) {
-                      Navigator.of(context).pop();
-                    }
-                  });
                 },
                 child: const Icon(
                   Icons.account_circle,
@@ -365,7 +358,9 @@ class _HomePageState extends State<HomePage> {
                   builder: (context, snapshot) {
                     if (snapshot.connectionState == ConnectionState.waiting) {
                       return const Center(
-                        child: CircularProgressIndicator(),
+                        child: CircularProgressIndicator(
+                          backgroundColor: Color(0xFF2A72E7),
+                        ),
                       );
                     } else if (snapshot.hasError) {
                       return const Center(

--- a/frontend/lib/screens/login_screen.dart
+++ b/frontend/lib/screens/login_screen.dart
@@ -319,12 +319,21 @@ class _LoginPageState extends State<LoginPage> {
                     children: [
                       TextFormField(
                         controller: idController,
+                        cursorColor: const Color(0xFF2A72E7),
                         decoration: const InputDecoration(
                           labelText: '학번',
-                          labelStyle: TextStyle(fontSize: 14.0),
+                          labelStyle: TextStyle(
+                            fontSize: 14.0,
+                            color: Colors.black,
+                          ),
                           border: OutlineInputBorder(
                             borderRadius: BorderRadius.all(
                               Radius.circular(5.0),
+                            ),
+                          ),
+                          focusedBorder: OutlineInputBorder(
+                            borderSide: BorderSide(
+                              color: Color(0xFF2A72E7),
                             ),
                           ),
                           contentPadding: EdgeInsets.symmetric(
@@ -346,12 +355,21 @@ class _LoginPageState extends State<LoginPage> {
                       // 비밀번호 텍스트폼필드
                       TextFormField(
                         controller: pwController,
+                        cursorColor: const Color(0xFF2A72E7),
                         decoration: InputDecoration(
                           labelText: '비밀번호',
-                          labelStyle: const TextStyle(fontSize: 14.0),
+                          labelStyle: const TextStyle(
+                            fontSize: 14.0,
+                            color: Colors.black,
+                          ),
                           border: const OutlineInputBorder(
                             borderRadius: BorderRadius.all(
                               Radius.circular(5.0),
+                            ),
+                          ),
+                          focusedBorder: const OutlineInputBorder(
+                            borderSide: BorderSide(
+                              color: Color(0xFF2A72E7),
                             ),
                           ),
                           suffixIcon: IconButton(

--- a/frontend/lib/screens/userInfo_screen.dart
+++ b/frontend/lib/screens/userInfo_screen.dart
@@ -6,6 +6,7 @@ import 'package:frontend/screens/editTool_screen.dart';
 import 'package:frontend/screens/myUserPage_screen.dart';
 import 'package:frontend/services/profile_service.dart';
 import 'package:provider/provider.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 class UserInfoPage extends StatefulWidget {
   final Map<String, dynamic> profile;
@@ -76,10 +77,12 @@ class _UserInfoPageState extends State<UserInfoPage> {
               ),
               const SizedBox(height: 20),
               // initState에서 초기화하지 않고 그냥 바로 지정
-              userInfo('희망분야', widget.profile['hopeJob']),
-              userInfo('깃허브 링크', widget.profile['githubLink']),
-              userInfo('Development Field', widget.profile['developmentField']),
-              userInfo('Development Tool', widget.profile['developmentTool']),
+              userInfo('희망분야', widget.profile['hopeJob'], false),
+              userInfo('깃허브 링크', widget.profile['githubLink'], true),
+              userInfo('Development Field', widget.profile['developmentField'],
+                  false),
+              userInfo(
+                  'Development Tool', widget.profile['developmentTool'], false),
             ],
           ),
         ),
@@ -102,27 +105,32 @@ class _UserInfoPageState extends State<UserInfoPage> {
     final result = await showDialog<Map<String, dynamic>>(
       context: context,
       builder: (context) {
+        final screenWidth = MediaQuery.of(context).size.width;
+
         return AlertDialog(
           backgroundColor: const Color(0xFFFFFFFF),
           title: const Text('프로필 수정하기'),
-          content: SingleChildScrollView(
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                // 수정 모달창에서는 컨트롤러로 보이게 작성
-                editTextField('희망분야', hopeJobController),
-                editTextField('깃허브 링크', githubLinkController),
-                editFieldTool(
-                  'Development Field',
-                  fieldController,
-                  '/edit-field',
-                ),
-                editFieldTool(
-                  'Development Tool',
-                  toolController,
-                  '/edit-tool',
-                ),
-              ],
+          content: SizedBox(
+            width: screenWidth * 0.9,
+            child: SingleChildScrollView(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  // 수정 모달창에서는 컨트롤러로 보이게 작성
+                  editTextField('희망분야', hopeJobController),
+                  editTextField('깃허브 링크', githubLinkController),
+                  editFieldTool(
+                    'Development Field',
+                    fieldController,
+                    '/edit-field',
+                  ),
+                  editFieldTool(
+                    'Development Tool',
+                    toolController,
+                    '/edit-tool',
+                  ),
+                ],
+              ),
             ),
           ),
           actions: [
@@ -187,7 +195,7 @@ class _UserInfoPageState extends State<UserInfoPage> {
   }
 
   // 회원 정보 위젯
-  Widget userInfo(String title, String info) {
+  Widget userInfo(String title, String info, bool isConnected) {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -202,11 +210,28 @@ class _UserInfoPageState extends State<UserInfoPage> {
           ),
         ),
         const SizedBox(height: 20),
-        Text(
-          info,
-          style: const TextStyle(
-            color: Colors.black,
-            fontSize: 14,
+        GestureDetector(
+          onTap: () async {
+            if (isConnected) {
+              final Uri uri = Uri.parse(info); // Uri 객체로 URL 생성
+
+              if (await canLaunchUrl(uri)) {
+                await launchUrl(
+                  uri,
+                );
+              } else {
+                throw '$info를 찾을 수 없습니다.';
+              }
+            }
+          },
+          child: Text(
+            info,
+            style: TextStyle(
+              fontSize: 14,
+              color: isConnected ? Colors.blue : Colors.black,
+              decoration: isConnected ? TextDecoration.underline : null,
+              decorationColor: Colors.blue,
+            ),
           ),
         ),
         const SizedBox(height: 20),

--- a/frontend/lib/screens/userInfo_screen.dart
+++ b/frontend/lib/screens/userInfo_screen.dart
@@ -4,8 +4,6 @@ import 'package:frontend/providers/profile_provider.dart';
 import 'package:frontend/screens/editField_screen.dart';
 import 'package:frontend/screens/editTool_screen.dart';
 import 'package:frontend/screens/myUserPage_screen.dart';
-import 'package:frontend/screens/setProfile_screen.dart';
-import 'package:frontend/screens/setSkill_screen.dart';
 import 'package:frontend/services/profile_service.dart';
 import 'package:provider/provider.dart';
 
@@ -20,41 +18,7 @@ class UserInfoPage extends StatefulWidget {
 enum PopUpItem { popUpItem1 }
 
 class _UserInfoPageState extends State<UserInfoPage> {
-  bool isEdited = false;
   List<Map<String, dynamic>> selectedFields = []; // 선택된 Field 리스트
-
-  int? memberId;
-
-  String developmentField = ''; // 수정할 때 값이 변경될 때 저장할려고 선언
-  String developmentTool = '';
-  String hopeJob = '';
-  String githubLink = '';
-
-  late TextEditingController hopeJobController;
-  late TextEditingController githubLinkController;
-
-  @override
-  void initState() {
-    super.initState();
-
-    // 저장된 값을 처음에 받기 위해 초기화로 지정
-    developmentField = widget.profile['developmentField'] ?? '없음';
-    developmentTool = widget.profile['developmentTool'] ?? '없음';
-    hopeJob = widget.profile['hopeJob'] ?? '';
-    githubLink = widget.profile['githubLink'] ?? '';
-    memberId = widget.profile['memberId'];
-
-    // 컨트롤러 초기화
-    hopeJobController = TextEditingController(text: hopeJob);
-    githubLinkController = TextEditingController(text: githubLink);
-  }
-
-  @override
-  void dispose() {
-    hopeJobController.dispose();
-    githubLinkController.dispose();
-    super.dispose();
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -67,7 +31,7 @@ class _UserInfoPageState extends State<UserInfoPage> {
         leading: BackButton(
           onPressed: () async {
             await Provider.of<ProfileProvider>(context, listen: false)
-                .fetchProfile(memberId!);
+                .fetchProfile(widget.profile['memberId']);
 
             if (context.mounted) {
               Navigator.pushAndRemoveUntil(
@@ -88,9 +52,7 @@ class _UserInfoPageState extends State<UserInfoPage> {
               itemBuilder: (BuildContext context) {
                 return [
                   popUpItem('수정하기', PopUpItem.popUpItem1, () {
-                    setState(() {
-                      isEdited = !isEdited;
-                    });
+                    editProfileDialog(context);
                   }),
                 ];
               },
@@ -106,72 +68,126 @@ class _UserInfoPageState extends State<UserInfoPage> {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               Text(
-                '${widget.profile['memberName']}님의 프로필',
+                '${widget.profile['memberName']} 프로필',
                 style: const TextStyle(
                   fontSize: 20,
                   fontWeight: FontWeight.bold,
                 ),
               ),
               const SizedBox(height: 20),
-              // userInfo('이름', '${widget.profile['memberName']}'),
-              // userInfo('학년', '${widget.profile['memberLevel']}'),
-              userInfo('희망분야', hopeJob, hopeJobController),
-              userInfo('깃허브 링크', githubLink, githubLinkController),
-              developmentInfo(
-                context,
-                'Development Field',
-                developmentField,
-                '/edit-field',
-              ),
-              developmentInfo(
-                context,
-                'Development Tool',
-                developmentTool,
-                '/edit-tool',
-              ),
+              // initState에서 초기화하지 않고 그냥 바로 지정
+              userInfo('희망분야', widget.profile['hopeJob']),
+              userInfo('깃허브 링크', widget.profile['githubLink']),
+              userInfo('Development Field', widget.profile['developmentField']),
+              userInfo('Development Tool', widget.profile['developmentTool']),
             ],
           ),
         ),
       ),
-      bottomNavigationBar: isEdited
-          ? ElevatedButton(
-              onPressed: () async {
-                setState(() {
-                  isEdited = false;
-                });
+    );
+  }
 
+  // 프로필 수정 모달창
+  void editProfileDialog(BuildContext context) async {
+    // 취소하고 모달창에 수정한 값이 보이는 오류로 인해 모달창 메서드 내부에서 초기화 지정
+    TextEditingController hopeJobController =
+        TextEditingController(text: widget.profile['hopeJob']);
+    TextEditingController githubLinkController =
+        TextEditingController(text: widget.profile['githubLink']);
+    TextEditingController fieldController =
+        TextEditingController(text: widget.profile['developmentField']);
+    TextEditingController toolController =
+        TextEditingController(text: widget.profile['developmentTool']);
+
+    final result = await showDialog<Map<String, dynamic>>(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          backgroundColor: const Color(0xFFFFFFFF),
+          title: const Text('프로필 수정하기'),
+          content: SingleChildScrollView(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                // 수정 모달창에서는 컨트롤러로 보이게 작성
+                editTextField('희망분야', hopeJobController),
+                editTextField('깃허브 링크', githubLinkController),
+                editFieldTool(
+                  'Development Field',
+                  fieldController,
+                  '/edit-field',
+                ),
+                editFieldTool(
+                  'Development Tool',
+                  toolController,
+                  '/edit-tool',
+                ),
+              ],
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () {
+                Navigator.pop(context);
+              },
+              child: const Text(
+                '취소',
+                style: TextStyle(
+                  color: Color(0xFF2A72E7),
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ),
+            TextButton(
+              onPressed: () async {
+                // 수정 요청 바디에는 controller.text로 전달(프로필 조회와 수정 페이지에서의 조회에서 어떻게 보여줄지 통일성을 갖기 위해)
                 final profile = Profile(
-                  hopeJob: hopeJob,
-                  githubLink: githubLink,
-                  developmentField: developmentField,
-                  developmentTool: developmentTool,
+                  hopeJob: hopeJobController.text,
+                  githubLink: githubLinkController.text,
+                  developmentField: fieldController.text,
+                  developmentTool: toolController.text,
                 );
 
                 print('수정된 profile; $profile');
 
                 await ProfileService()
                     .updateProfile(profile); // provider에서 할 작업이 없어서 service로 호출
+
+                if (context.mounted) {
+                  // 수정된 값 전달
+                  Navigator.pop(context, {
+                    'hopeJob': hopeJobController.text,
+                    'githubLink': githubLinkController.text,
+                    'developmentField': fieldController.text,
+                    'developmentTool': toolController.text,
+                  });
+                }
               },
-              style: ElevatedButton.styleFrom(
-                backgroundColor: const Color(0xFFDBE7FB),
-                foregroundColor: const Color(0xFF000000).withOpacity(0.5),
-                shape: const RoundedRectangleBorder(
-                  borderRadius: BorderRadius.zero,
-                ),
-              ),
               child: const Text(
-                '완료',
+                '저장',
                 style: TextStyle(
+                  color: Color(0xFF2A72E7),
                   fontWeight: FontWeight.bold,
                 ),
               ),
-            )
-          : null,
+            ),
+          ],
+        );
+      },
     );
+    // 다이얼로그에서 반환된 값으로 상태 업데이트
+    if (result != null) {
+      setState(() {
+        widget.profile['hopeJob'] = result['hopeJob']!;
+        widget.profile['githubLink'] = result['githubLink']!;
+        widget.profile['developmentField'] = result['developmentField']!;
+        widget.profile['developmentTool'] = result['developmentTool']!;
+      });
+    }
   }
 
   // 회원 정보 위젯
-  Widget userInfo(String title, String info, TextEditingController controller) {
+  Widget userInfo(String title, String info) {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -185,88 +201,92 @@ class _UserInfoPageState extends State<UserInfoPage> {
             color: Color(0xFF808080),
           ),
         ),
-        const SizedBox(height: 10),
-        TextFormField(
-          controller: controller,
-          readOnly: !isEdited,
-          style: TextStyle(
-            color: isEdited ? Colors.black : Colors.grey,
+        const SizedBox(height: 20),
+        Text(
+          info,
+          style: const TextStyle(
+            color: Colors.black,
+            fontSize: 14,
           ),
-          decoration: const InputDecoration(
-            border: InputBorder.none,
-          ),
-          onChanged: (value) {
-            setState(() {
-              if (title == '희망분야') {
-                hopeJob = value;
-              } else if (title == '깃허브 링크') {
-                githubLink = value;
-              }
-            });
-          },
         ),
+        const SizedBox(height: 20),
       ],
     );
   }
 
-  // 회원 정보 위젯
-  Widget developmentInfo(
-      BuildContext context, String title, String info, String path) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        const Divider(),
-        const SizedBox(height: 15),
-        Row(
-          children: [
-            Text(
-              title,
-              style: const TextStyle(
-                fontSize: 16,
-                fontWeight: FontWeight.bold,
-                color: Color(0xFF808080),
-              ),
-            ),
-            const SizedBox(width: 5),
-            if (isEdited)
-              IconButton(
-                onPressed: () async {
-                  // 전달받은 데이터값을 result에 저장해 developmentField에 저장
-
-                  final result = await Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                      builder: (context) => (path == '/edit-field')
-                          ? const EditFieldPage()
-                          : const EditToolPage(),
-                    ),
-                  );
-
-                  if (result != null && result is String) {
-                    setState(() {
-                      if (path == '/edit-field') {
-                        developmentField = result;
-                      } else if (path == '/edit-tool') {
-                        developmentTool = result;
-                      }
-                    });
-                  }
-                },
-                icon: const Icon(
-                  Icons.edit,
-                  size: 20,
-                ),
-              ),
-          ],
+  // 수정할 텍스트필드 위젯
+  Widget editTextField(String title, TextEditingController controller) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8.0),
+      child: TextFormField(
+        controller: controller,
+        style: const TextStyle(
+          color: Colors.black,
         ),
-        const SizedBox(height: 10),
-        Text(info),
-        const SizedBox(height: 10),
-      ],
+        cursorColor: const Color(0xFF2A72E7),
+        decoration: InputDecoration(
+          labelText: title,
+          labelStyle: const TextStyle(
+            color: Colors.black,
+          ),
+          border: const OutlineInputBorder(),
+          focusedBorder: const OutlineInputBorder(
+            borderSide: BorderSide(
+              color: Color(0xFF2A72E7),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  // 수정할 개발 툴, 필드
+  Widget editFieldTool(
+      String title, TextEditingController controller, String path) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8.0),
+      child: TextFormField(
+        onTap: () async {
+          // 전달받은 데이터값을 result에 저장해 developmentField에 저장
+          final result = await Navigator.push(
+            context,
+            MaterialPageRoute(
+              builder: (context) => (path == '/edit-field')
+                  ? const EditFieldPage()
+                  : const EditToolPage(),
+            ),
+          );
+
+          if (result != null && result is String) {
+            setState(() {
+              if (path == '/edit-field') {
+                controller.text = result;
+              } else if (path == '/edit-tool') {
+                controller.text = result;
+              }
+            });
+          }
+        },
+        controller: controller,
+        readOnly: true,
+        style: const TextStyle(
+          color: Colors.black,
+        ),
+        cursorColor: const Color(0xFF2A72E7),
+        decoration: InputDecoration(
+          labelText: title,
+          labelStyle: const TextStyle(
+            color: Colors.black,
+          ),
+          border: const OutlineInputBorder(),
+          focusedBorder: const OutlineInputBorder(),
+        ),
+      ),
     );
   }
 }
 
+// 팝업 메뉴
 PopupMenuItem<PopUpItem> popUpItem(
     String text, PopUpItem item, Function() onTap) {
   return PopupMenuItem<PopUpItem>(

--- a/frontend/lib/services/login_services.dart
+++ b/frontend/lib/services/login_services.dart
@@ -349,13 +349,3 @@ class LoginAPI {
     }
   }
 }
-
-// 개발 환경에서만 사용해야되고 보안상 위험하기 때문에 프로덕션 환경에서 사용하면 절대 안된다.
-class MyHttpOverrides extends HttpOverrides {
-  @override
-  HttpClient createHttpClient(SecurityContext? context) {
-    return super.createHttpClient(context)
-      ..badCertificateCallback =
-          (X509Certificate cert, String host, int port) => true;
-  }
-}


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
#240

## ✨ 코드 변경 내용
<!-- 코드 변경에 대한 설명을 적어주세요 -->
### 프로필 수정 로직 수정
- 프로필 조회는 Text 위젯을 사용해 userPage에서 받은 profile로 구현
- 프로필 수정 모달창에서 controller로 볼 수 있게 해놨고 수정할 때도 값들을 controller.text로 값을 보냄
- 저장 버튼 시 userInfo 페이지에서 바로 업뎃시키기 위해 모달창을 Map으로 반환타입을 지정해
결과값을 widget.profile에 저장
- 취소하고 모달창에 수정된게 보이는 오류가 발생해 initState에 값들과 컨트롤러를 저장을 제거하고
컨트롤러는 모달창 함수에 초기화
### 깃허브 링크에 해당 웹사이트로 이동하는 기능 구현
- url_launcher 패키지를 사용하고 파란 색상으로 변경
- 홈페이지에서 마이페이지로 이동할 때 3초 후 다이얼로그 닫는 코드 제거
- 로그인 페이지에서 커서, 포커스 색상을 앱 대표 색상으로 변경

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
