### PR TITLE
[Feat/#252] 경험 여러 개 추가하기

### DIFF
--- a/frontend/lib/screens/setExperience_screen.dart
+++ b/frontend/lib/screens/setExperience_screen.dart
@@ -177,7 +177,9 @@ class _SetExperiencePageState extends State<SetExperiencePage> {
         final githubLink = 'https://github.com/${githubLinkController[0].text}';
         final roll = selectedRole[0];
         final part = partController[0].text;
-        final duration = selectedDuration[0] ?? customDurationValue[0];
+        final duration = (selectedDuration[0] == '직접 입력')
+            ? customDurationValue[0]
+            : selectedDuration[0];
 
         ProjectExperience newExperience = ProjectExperience(
           experienceName: projectName,
@@ -185,7 +187,7 @@ class _SetExperiencePageState extends State<SetExperiencePage> {
           experienceContent: projectExperience,
           experienceGithub: githubLink,
           experienceJob: part,
-          experienceDate: duration,
+          experienceDate: duration!,
         );
 
         writtenText = true;
@@ -193,6 +195,36 @@ class _SetExperiencePageState extends State<SetExperiencePage> {
 
         final provider = context.read<ProjectExperienceProvider>();
         await provider.createProjectExperience(newExperience);
+
+        // 경험을 여러 개 작성한 경우
+      } else if (projectNameController.length > 1) {
+        List<ProjectExperience> newExperiences = [];
+
+        for (int i = 0; i < projectNameController.length; i++) {
+          final projectName = projectNameController[i].text;
+          final projectExperience = projectExperienceController[i].text;
+          final githubLink =
+              'https://github.com/${githubLinkController[i].text}';
+          final roll = selectedRole[i];
+          final part = partController[i].text;
+          final duration = (selectedDuration[i] == '직접 입력')
+              ? customDurationValue[i]
+              : selectedDuration[i];
+
+          ProjectExperience newExperience = ProjectExperience(
+            experienceName: projectName,
+            experienceRole: roll!,
+            experienceContent: projectExperience,
+            experienceGithub: githubLink,
+            experienceJob: part,
+            experienceDate: duration!,
+          );
+
+          newExperiences.add(newExperience); // 경험 리스트에 추가
+        }
+        final provider = context.read<ProjectExperienceProvider>();
+        await provider
+            .createProjectExperiences(newExperiences); // 경험 여러개 작성 API 호출
       }
 
       if (context.mounted) {
@@ -248,6 +280,9 @@ class _SetExperiencePageState extends State<SetExperiencePage> {
 
   @override
   Widget build(BuildContext context) {
+    // 키보드가 올라왔는지 확인
+    final isKeyboardVisible = MediaQuery.of(context).viewInsets.bottom > 0;
+
     return Scaffold(
       backgroundColor: Colors.white,
       body: Padding(
@@ -311,9 +346,15 @@ class _SetExperiencePageState extends State<SetExperiencePage> {
                               Radius.circular(5.0),
                             ),
                           ),
+                          focusedBorder: OutlineInputBorder(
+                            borderSide: BorderSide(
+                              color: Color(0xFF2A72E7),
+                            ),
+                          ),
                           contentPadding: EdgeInsets.symmetric(
                               horizontal: 10.0, vertical: 5.0),
                         ),
+                        cursorColor: const Color(0xFF2A72E7),
                         style: const TextStyle(
                           fontSize: 12,
                         ),
@@ -342,6 +383,11 @@ class _SetExperiencePageState extends State<SetExperiencePage> {
                               Radius.circular(5.0),
                             ),
                           ),
+                          focusedBorder: OutlineInputBorder(
+                            borderSide: BorderSide(
+                              color: Color(0xFF2A72E7),
+                            ),
+                          ),
                           contentPadding: EdgeInsets.symmetric(
                               horizontal: 10.0, vertical: 5.0),
                         ),
@@ -359,6 +405,7 @@ class _SetExperiencePageState extends State<SetExperiencePage> {
                       ),
 
                       const SizedBox(height: 10),
+
                       // 프로젝트 경험 입력 필드
                       TextFormField(
                         controller: projectExperienceController[index],
@@ -380,9 +427,15 @@ class _SetExperiencePageState extends State<SetExperiencePage> {
                               Radius.circular(5.0),
                             ),
                           ),
+                          focusedBorder: OutlineInputBorder(
+                            borderSide: BorderSide(
+                              color: Color(0xFF2A72E7),
+                            ),
+                          ),
                           contentPadding: EdgeInsets.symmetric(
                               horizontal: 10.0, vertical: 5.0),
                         ),
+                        cursorColor: const Color(0xFF2A72E7),
                         style: const TextStyle(
                           fontSize: 12,
                         ),
@@ -411,9 +464,15 @@ class _SetExperiencePageState extends State<SetExperiencePage> {
                               Radius.circular(5.0),
                             ),
                           ),
+                          focusedBorder: OutlineInputBorder(
+                            borderSide: BorderSide(
+                              color: Color(0xFF2A72E7),
+                            ),
+                          ),
                           contentPadding: EdgeInsets.symmetric(
                               horizontal: 10.0, vertical: 5.0),
                         ),
+                        cursorColor: const Color(0xFF2A72E7),
                         style: const TextStyle(
                           fontSize: 12,
                         ),
@@ -437,9 +496,15 @@ class _SetExperiencePageState extends State<SetExperiencePage> {
                               Radius.circular(5.0),
                             ),
                           ),
+                          focusedBorder: OutlineInputBorder(
+                            borderSide: BorderSide(
+                              color: Color(0xFF2A72E7),
+                            ),
+                          ),
                           contentPadding: EdgeInsets.symmetric(
                               horizontal: 10.0, vertical: 5.0),
                         ),
+                        cursorColor: const Color(0xFF2A72E7),
                         style: const TextStyle(
                           fontSize: 12,
                         ),
@@ -470,6 +535,11 @@ class _SetExperiencePageState extends State<SetExperiencePage> {
                             ),
                             borderRadius: BorderRadius.all(
                               Radius.circular(5.0),
+                            ),
+                          ),
+                          focusedBorder: OutlineInputBorder(
+                            borderSide: BorderSide(
+                              color: Color(0xFF2A72E7),
                             ),
                           ),
                           contentPadding: EdgeInsets.symmetric(
@@ -509,9 +579,15 @@ class _SetExperiencePageState extends State<SetExperiencePage> {
                                   Radius.circular(5.0),
                                 ),
                               ),
+                              focusedBorder: OutlineInputBorder(
+                                borderSide: BorderSide(
+                                  color: Color(0xFF2A72E7),
+                                ),
+                              ),
                               contentPadding: EdgeInsets.symmetric(
                                   horizontal: 10.0, vertical: 5.0),
                             ),
+                            cursorColor: const Color(0xFF2A72E7),
                             style: const TextStyle(
                               fontSize: 12,
                             ),
@@ -522,7 +598,7 @@ class _SetExperiencePageState extends State<SetExperiencePage> {
                       //   Padding(
                       //     padding: const EdgeInsets.symmetric(vertical: 10.0),
                       //     child: Text(
-                      //       '직접 입력한 프로젝트 기간: $customDurationValue',
+                      //       '직접 입력한 프로젝트 기간: ${customDurationValue[index]}',
                       //       style: const TextStyle(
                       //         fontSize: 12,
                       //         color: Color(0xFF808080),
@@ -543,37 +619,41 @@ class _SetExperiencePageState extends State<SetExperiencePage> {
                 ),
                 itemCount: formatLength,
               ),
+              SizedBox(height: isKeyboardVisible ? 10 : 0),
 
               // 겸험 추가하기 버튼
-              ElevatedButton(
-                onPressed: () {
-                  setState(() {
-                    formatLength++;
-                  });
-                  _addNewExperienceFields();
-                },
-                style: ElevatedButton.styleFrom(
-                  padding: const EdgeInsets.symmetric(vertical: 10),
-                  backgroundColor: Colors.transparent,
-                  elevation: 0,
-                  side: const BorderSide(
-                    color: Colors.blueAccent,
-                  ),
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(8.0),
-                  ),
-                ),
-                child: const Center(
-                  child: Text(
-                    '경험 추가하기',
-                    style: TextStyle(
-                      color: Colors.blueAccent,
-                      fontWeight: FontWeight.bold,
-                      fontSize: 16,
+              (widget.update! == true)
+                  ? Container()
+                  : ElevatedButton(
+                      onPressed: () {
+                        setState(() {
+                          formatLength++;
+                        });
+                        _addNewExperienceFields(); // 컨트롤러 혹은 문자열 리스트 요소 추가
+                      },
+                      style: ElevatedButton.styleFrom(
+                        padding: const EdgeInsets.symmetric(vertical: 10),
+                        backgroundColor: Colors.transparent,
+                        elevation: 0,
+                        side: const BorderSide(
+                          color: Colors.blueAccent,
+                        ),
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(8.0),
+                        ),
+                      ),
+                      child: const Center(
+                        child: Text(
+                          '경험 추가하기',
+                          style: TextStyle(
+                            color: Colors.blueAccent,
+                            fontWeight: FontWeight.bold,
+                            fontSize: 16,
+                          ),
+                        ),
+                      ),
                     ),
-                  ),
-                ),
-              ),
+
               const SizedBox(height: 10),
 
               // 알리미 시작하기 또는 없음 버튼

--- a/frontend/lib/screens/setExperience_screen.dart
+++ b/frontend/lib/screens/setExperience_screen.dart
@@ -18,20 +18,20 @@ class SetExperiencePage extends StatefulWidget {
 }
 
 class _SetExperiencePageState extends State<SetExperiencePage> {
-  double percent = 0.75; // 프로그레스 바 진행률
-  TextEditingController projectNameController =
-      TextEditingController(); // 프로젝트명 입력 컨트롤러
-  TextEditingController projectExperienceController =
-      TextEditingController(); // 프로젝트 경험 입력 컨트롤러
-  TextEditingController githubLinkController =
-      TextEditingController(); // 깃허브 링크 입력 컨트롤러
-  TextEditingController rollController = TextEditingController(); // 역할 입력 컨트롤러
-  TextEditingController partController =
-      TextEditingController(); // 맡은 파트 입력 컨트롤러
-  String? selectedDuration; // 선택된 프로젝트 기간을 저장하는 함수
-  String? selectedRole; // 드롭다운에서 선택된 역할을 저장하는 변수
   bool writtenText = false;
-  String customDurationValue = ''; // 직접 입력된 프로젝트 기간을 저장하는 변수
+
+  double percent = 0.75; // 프로그레스 바 진행률
+  int formatLength = 1; // 작성 양식 개수(경험 추가하기 버튼 누르면 증가)
+
+  List<TextEditingController> projectNameController = []; // 프로젝트명 입력 컨트롤러
+  List<TextEditingController> projectExperienceController =
+      []; // 프로젝트 경험 입력 컨트롤러
+  List<TextEditingController> githubLinkController = []; // 깃허브 링크 입력 컨트롤러
+  List<TextEditingController> partController = []; // 맡은 파트 입력 컨트롤러
+
+  List<String?> selectedDuration = []; // 선택된 프로젝트 기간을 저장하는 함수
+  List<String?> selectedRole = []; // 드롭다운에서 선택된 역할을 저장하는 변수
+  List<String> customDurationValue = []; // 직접 입력된 프로젝트 기간을 저장하는 변수
 
   List<String> projectDurationOptions = [
     '1개월',
@@ -45,21 +45,57 @@ class _SetExperiencePageState extends State<SetExperiencePage> {
   @override
   void initState() {
     super.initState();
-    projectNameController.addListener(_updateTextState);
-    projectExperienceController.addListener(_updateTextState);
-    githubLinkController.addListener(_updateTextState);
-    rollController.addListener(_updateTextState);
-    partController.addListener(_updateTextState);
+    _addNewExperienceFields();
   }
 
   @override
   void dispose() {
-    projectNameController.dispose();
-    projectExperienceController.dispose();
-    githubLinkController.dispose();
-    rollController.dispose();
-    partController.dispose();
+    // 모든 컨트롤러 해제
+    for (var controller in projectNameController) {
+      controller.dispose();
+    }
+    for (var controller in projectExperienceController) {
+      controller.dispose();
+    }
+    for (var controller in githubLinkController) {
+      controller.dispose();
+    }
+    for (var controller in partController) {
+      controller.dispose();
+    }
     super.dispose();
+  }
+
+  // 경험 추가하기 버튼을 통해 새로운 컨트롤러 혹은 String 추가
+  void _addNewExperienceFields() {
+    setState(() {
+      // 새로운 TextEditingController 추가
+      projectNameController.add(TextEditingController());
+      projectExperienceController.add(TextEditingController());
+      githubLinkController.add(TextEditingController());
+      partController.add(TextEditingController());
+      selectedDuration.add(null);
+      selectedRole.add(null);
+      customDurationValue.add('');
+    });
+  }
+
+  // 해당 인덱스의 컨트롤러 혹은 String 삭제
+  void _removeExperienceFields(int index) {
+    setState(() {
+      projectNameController[index].dispose();
+      projectExperienceController[index].dispose();
+      githubLinkController[index].dispose();
+      partController[index].dispose();
+
+      projectNameController.removeAt(index);
+      projectExperienceController.removeAt(index);
+      githubLinkController.removeAt(index);
+      partController.removeAt(index);
+      selectedDuration.removeAt(index);
+      selectedRole.removeAt(index);
+      customDurationValue.removeAt(index);
+    });
   }
 
   void _updateTextState() {
@@ -68,12 +104,12 @@ class _SetExperiencePageState extends State<SetExperiencePage> {
 
   Future<void> _onTapHandler() async {
     // '없음' 버튼이 클릭된 경우 모든 입력을 빈 배열로 처리
-    if (projectNameController.text.isEmpty &&
-        projectExperienceController.text.isEmpty &&
-        githubLinkController.text.isEmpty &&
-        rollController.text.isEmpty &&
-        partController.text.isEmpty &&
-        (selectedDuration == null && customDurationValue.isEmpty)) {
+    if (projectNameController[0].text.isEmpty &&
+        projectExperienceController[0].text.isEmpty &&
+        githubLinkController[0].text.isEmpty &&
+        partController[0].text.isEmpty &&
+        selectedRole[0] == null &&
+        (selectedDuration[0] == null || customDurationValue[0].isEmpty)) {
       // 빈 배열로 설정
       ProjectExperience emptyExperience = ProjectExperience(
         experienceName: '[]', // 빈 배열 값
@@ -134,28 +170,30 @@ class _SetExperiencePageState extends State<SetExperiencePage> {
         }
       }
     } else {
-      // 기존 입력 처리 로직 유지
-      final projectName = projectNameController.text;
-      final projectExperience = projectExperienceController.text;
-      final githubLink = 'https://github.com/${githubLinkController.text}';
-      final roll = rollController.text;
-      final part = partController.text;
-      final duration = selectedDuration ?? customDurationValue;
+      // 경험을 1개만 작성했을 경우
+      if (projectNameController.length == 1) {
+        final projectName = projectNameController[0].text;
+        final projectExperience = projectExperienceController[0].text;
+        final githubLink = 'https://github.com/${githubLinkController[0].text}';
+        final roll = selectedRole[0];
+        final part = partController[0].text;
+        final duration = selectedDuration[0] ?? customDurationValue[0];
 
-      writtenText = true;
-      percent = 1;
+        ProjectExperience newExperience = ProjectExperience(
+          experienceName: projectName,
+          experienceRole: roll!,
+          experienceContent: projectExperience,
+          experienceGithub: githubLink,
+          experienceJob: part,
+          experienceDate: duration,
+        );
 
-      ProjectExperience newExperience = ProjectExperience(
-        experienceName: projectName,
-        experienceRole: roll,
-        experienceContent: projectExperience,
-        experienceGithub: githubLink,
-        experienceJob: part,
-        experienceDate: duration,
-      );
+        writtenText = true;
+        percent = 1;
 
-      final provider = context.read<ProjectExperienceProvider>();
-      await provider.createProjectExperience(newExperience);
+        final provider = context.read<ProjectExperienceProvider>();
+        await provider.createProjectExperience(newExperience);
+      }
 
       if (context.mounted) {
         if (widget.update == true) {
@@ -246,209 +284,21 @@ class _SetExperiencePageState extends State<SetExperiencePage> {
                 'assets/images/projectExperience.png',
                 width: 200,
               ),
-              const SizedBox(height: 59),
-              Column(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  // 프로젝트명 입력 필드
-                  TextFormField(
-                    controller: projectNameController,
-                    decoration: const InputDecoration(
-                      labelText: '프로젝트명을 입력해주세요',
-                      labelStyle: TextStyle(
-                        fontSize: 12,
-                        color: Color(0xFF808080),
-                      ),
-                      border: OutlineInputBorder(
-                        borderSide: BorderSide(
-                          color: Colors.black,
-                        ),
-                        borderRadius: BorderRadius.all(
-                          Radius.circular(5.0),
-                        ),
-                      ),
-                      contentPadding:
-                          EdgeInsets.symmetric(horizontal: 10.0, vertical: 5.0),
-                    ),
-                    style: const TextStyle(
-                      fontSize: 12,
-                    ),
-                  ),
-                  const SizedBox(height: 10),
+              const SizedBox(height: 10),
 
-                  // 역할 선택 드롭다운
-                  DropdownButtonFormField<String>(
-                    value: selectedRole, // 초기 선택값, 필요 시 변수 초기화
-                    onChanged: (String? newValue) {
-                      setState(() {
-                        selectedRole = newValue; // 선택된 값을 상태로 업데이트
-                      });
-                    },
-                    decoration: const InputDecoration(
-                      labelText: '나의 역할(LEADER, MEMBER)을 선택해주세요',
-                      labelStyle: TextStyle(
-                        fontSize: 12,
-                        color: Color(0xFF808080),
-                      ),
-                      border: OutlineInputBorder(
-                        borderSide: BorderSide(
-                          color: Colors.black,
-                        ),
-                        borderRadius: BorderRadius.all(
-                          Radius.circular(5.0),
-                        ),
-                      ),
-                      contentPadding:
-                          EdgeInsets.symmetric(horizontal: 10.0, vertical: 5.0),
-                    ),
-                    style: const TextStyle(
-                      fontSize: 12,
-                      color: Colors.black,
-                    ),
-                    dropdownColor: Colors.white, // 드롭다운 메뉴의 배경 색상
-                    items: ['LEADER', 'MEMBER'].map((String value) {
-                      return DropdownMenuItem<String>(
-                        value: value,
-                        child: Text(value),
-                      );
-                    }).toList(),
-                  ),
-
-                  const SizedBox(height: 10),
-                  // 프로젝트 경험 입력 필드
-                  TextFormField(
-                    controller: projectExperienceController,
-                    maxLines: 4,
-                    keyboardType: TextInputType.multiline, // 줄바꿈 가능한 키보드
-                    textInputAction: TextInputAction.done, // 키보드에 '확인' 버튼을 추가
-                    decoration: const InputDecoration(
-                      labelText: '프로젝트 경험을 입력해주세요',
-                      labelStyle: TextStyle(
-                        fontSize: 12,
-                        color: Color(0xFF808080),
-                      ),
-                      border: OutlineInputBorder(
-                        borderSide: BorderSide(
-                          color: Colors.black,
-                        ),
-                        borderRadius: BorderRadius.all(
-                          Radius.circular(5.0),
-                        ),
-                      ),
-                      contentPadding:
-                          EdgeInsets.symmetric(horizontal: 10.0, vertical: 5.0),
-                    ),
-                    style: const TextStyle(
-                      fontSize: 12,
-                    ),
-                  ),
-                  const SizedBox(height: 10),
-                  // 깃허브 링크 입력 필드
-                  TextFormField(
-                    controller: githubLinkController,
-                    decoration: const InputDecoration(
-                      labelText: '깃허브 프로젝트 링크를 입력해주세요',
-                      labelStyle: TextStyle(
-                        fontSize: 12,
-                        color: Color(0xFF808080),
-                      ),
-                      prefixText: 'https://github.com/',
-                      prefixStyle: TextStyle(
-                        fontSize: 12,
-                        color: Colors.black,
-                      ),
-                      border: OutlineInputBorder(
-                        borderSide: BorderSide(
-                          color: Colors.black,
-                        ),
-                        borderRadius: BorderRadius.all(
-                          Radius.circular(5.0),
-                        ),
-                      ),
-                      contentPadding:
-                          EdgeInsets.symmetric(horizontal: 10.0, vertical: 5.0),
-                    ),
-                    style: const TextStyle(
-                      fontSize: 12,
-                    ),
-                  ),
-                  const SizedBox(height: 10),
-                  // 맡은 파트 입력 필드
-                  TextFormField(
-                    controller: partController,
-                    decoration: const InputDecoration(
-                      labelText: '맡은 파트를 입력해주세요',
-                      labelStyle: TextStyle(
-                        fontSize: 12,
-                        color: Color(0xFF808080),
-                      ),
-                      border: OutlineInputBorder(
-                        borderSide: BorderSide(
-                          color: Colors.black,
-                        ),
-                        borderRadius: BorderRadius.all(
-                          Radius.circular(5.0),
-                        ),
-                      ),
-                      contentPadding:
-                          EdgeInsets.symmetric(horizontal: 10.0, vertical: 5.0),
-                    ),
-                    style: const TextStyle(
-                      fontSize: 12,
-                    ),
-                  ),
-                  const SizedBox(height: 10),
-                  // 프로젝트 기간 드롭다운
-                  DropdownButtonFormField<String>(
-                    value: selectedDuration,
-                    onChanged: (String? newValue) {
-                      setState(() {
-                        selectedDuration = newValue;
-                        // 선택된 값이 "직접 입력"이 아닐 때, 직접 입력 값을 초기화
-                        if (newValue != '직접 입력') {
-                          customDurationValue = '';
-                        }
-                      });
-                    },
-                    decoration: const InputDecoration(
-                      labelText: '프로젝트 기간을 선택해주세요',
-                      labelStyle: TextStyle(
-                        fontSize: 12,
-                        color: Color(0xFF808080),
-                      ),
-                      border: OutlineInputBorder(
-                        borderSide: BorderSide(
-                          color: Colors.black,
-                        ),
-                        borderRadius: BorderRadius.all(
-                          Radius.circular(5.0),
-                        ),
-                      ),
-                      contentPadding:
-                          EdgeInsets.symmetric(horizontal: 10.0, vertical: 5.0),
-                    ),
-                    style: const TextStyle(
-                      fontSize: 12,
-                      color: Color(0xFF808080),
-                    ),
-                    dropdownColor: Colors.white, // 드롭다운 메뉴의 배경 색상
-                    items: projectDurationOptions.map((String value) {
-                      return DropdownMenuItem<String>(
-                        value: value,
-                        child: Text(value),
-                      );
-                    }).toList(),
-                  ),
-                  if (selectedDuration == '직접 입력' &&
-                      customDurationValue.isEmpty)
-                    Padding(
-                      padding: const EdgeInsets.symmetric(vertical: 10.0),
-                      child: TextFormField(
-                        onChanged: (value) {
-                          customDurationValue = value;
-                        },
+              // 경험 작성 양식
+              ListView.separated(
+                shrinkWrap: true,
+                physics: const NeverScrollableScrollPhysics(),
+                itemBuilder: (BuildContext context, int index) {
+                  return Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      // 프로젝트명 입력 필드
+                      TextFormField(
+                        controller: projectNameController[index],
                         decoration: const InputDecoration(
-                          labelText: '프로젝트 기간을 직접 입력해주세요',
+                          labelText: '프로젝트명을 입력해주세요',
                           labelStyle: TextStyle(
                             fontSize: 12,
                             color: Color(0xFF808080),
@@ -468,52 +318,295 @@ class _SetExperiencePageState extends State<SetExperiencePage> {
                           fontSize: 12,
                         ),
                       ),
-                    ),
-                  if (customDurationValue.isNotEmpty) // 직접 입력된 기간이 있을 때만 보여줌
-                    Padding(
-                      padding: const EdgeInsets.symmetric(vertical: 10.0),
-                      child: Text(
-                        '직접 입력한 프로젝트 기간: $customDurationValue',
+                      const SizedBox(height: 10),
+
+                      // 역할 선택 드롭다운
+                      DropdownButtonFormField<String>(
+                        value: selectedRole[index], // 초기 선택값, 필요 시 변수 초기화
+                        onChanged: (String? newValue) {
+                          setState(() {
+                            selectedRole[index] = newValue; // 선택된 값을 상태로 업데이트
+                          });
+                        },
+                        decoration: const InputDecoration(
+                          labelText: '나의 역할(LEADER, MEMBER)을 선택해주세요',
+                          labelStyle: TextStyle(
+                            fontSize: 12,
+                            color: Color(0xFF808080),
+                          ),
+                          border: OutlineInputBorder(
+                            borderSide: BorderSide(
+                              color: Colors.black,
+                            ),
+                            borderRadius: BorderRadius.all(
+                              Radius.circular(5.0),
+                            ),
+                          ),
+                          contentPadding: EdgeInsets.symmetric(
+                              horizontal: 10.0, vertical: 5.0),
+                        ),
+                        style: const TextStyle(
+                          fontSize: 12,
+                          color: Colors.black,
+                        ),
+                        dropdownColor: Colors.white, // 드롭다운 메뉴의 배경 색상
+                        items: ['LEADER', 'MEMBER'].map((String value) {
+                          return DropdownMenuItem<String>(
+                            value: value,
+                            child: Text(value),
+                          );
+                        }).toList(),
+                      ),
+
+                      const SizedBox(height: 10),
+                      // 프로젝트 경험 입력 필드
+                      TextFormField(
+                        controller: projectExperienceController[index],
+                        maxLines: 4,
+                        keyboardType: TextInputType.multiline, // 줄바꿈 가능한 키보드
+                        textInputAction:
+                            TextInputAction.done, // 키보드에 '확인' 버튼을 추가
+                        decoration: const InputDecoration(
+                          labelText: '프로젝트 경험을 입력해주세요',
+                          labelStyle: TextStyle(
+                            fontSize: 12,
+                            color: Color(0xFF808080),
+                          ),
+                          border: OutlineInputBorder(
+                            borderSide: BorderSide(
+                              color: Colors.black,
+                            ),
+                            borderRadius: BorderRadius.all(
+                              Radius.circular(5.0),
+                            ),
+                          ),
+                          contentPadding: EdgeInsets.symmetric(
+                              horizontal: 10.0, vertical: 5.0),
+                        ),
+                        style: const TextStyle(
+                          fontSize: 12,
+                        ),
+                      ),
+                      const SizedBox(height: 10),
+
+                      // 깃허브 링크 입력 필드
+                      TextFormField(
+                        controller: githubLinkController[index],
+                        decoration: const InputDecoration(
+                          labelText: '깃허브 프로젝트 링크를 입력해주세요',
+                          labelStyle: TextStyle(
+                            fontSize: 12,
+                            color: Color(0xFF808080),
+                          ),
+                          prefixText: 'https://github.com/',
+                          prefixStyle: TextStyle(
+                            fontSize: 12,
+                            color: Colors.black,
+                          ),
+                          border: OutlineInputBorder(
+                            borderSide: BorderSide(
+                              color: Colors.black,
+                            ),
+                            borderRadius: BorderRadius.all(
+                              Radius.circular(5.0),
+                            ),
+                          ),
+                          contentPadding: EdgeInsets.symmetric(
+                              horizontal: 10.0, vertical: 5.0),
+                        ),
+                        style: const TextStyle(
+                          fontSize: 12,
+                        ),
+                      ),
+                      const SizedBox(height: 10),
+
+                      // 맡은 파트 입력 필드
+                      TextFormField(
+                        controller: partController[index],
+                        decoration: const InputDecoration(
+                          labelText: '맡은 파트를 입력해주세요',
+                          labelStyle: TextStyle(
+                            fontSize: 12,
+                            color: Color(0xFF808080),
+                          ),
+                          border: OutlineInputBorder(
+                            borderSide: BorderSide(
+                              color: Colors.black,
+                            ),
+                            borderRadius: BorderRadius.all(
+                              Radius.circular(5.0),
+                            ),
+                          ),
+                          contentPadding: EdgeInsets.symmetric(
+                              horizontal: 10.0, vertical: 5.0),
+                        ),
+                        style: const TextStyle(
+                          fontSize: 12,
+                        ),
+                      ),
+                      const SizedBox(height: 10),
+
+                      // 프로젝트 기간 드롭다운
+                      DropdownButtonFormField<String>(
+                        value: selectedDuration[index],
+                        onChanged: (String? newValue) {
+                          setState(() {
+                            selectedDuration[index] = newValue;
+                            // 선택된 값이 "직접 입력"이 아닐 때, 직접 입력 값을 초기화
+                            if (newValue != '직접 입력') {
+                              customDurationValue[index] = '';
+                            }
+                          });
+                        },
+                        decoration: const InputDecoration(
+                          labelText: '프로젝트 기간을 선택해주세요',
+                          labelStyle: TextStyle(
+                            fontSize: 12,
+                            color: Color(0xFF808080),
+                          ),
+                          border: OutlineInputBorder(
+                            borderSide: BorderSide(
+                              color: Colors.black,
+                            ),
+                            borderRadius: BorderRadius.all(
+                              Radius.circular(5.0),
+                            ),
+                          ),
+                          contentPadding: EdgeInsets.symmetric(
+                              horizontal: 10.0, vertical: 5.0),
+                        ),
                         style: const TextStyle(
                           fontSize: 12,
                           color: Color(0xFF808080),
                         ),
+                        dropdownColor: Colors.white, // 드롭다운 메뉴의 배경 색상
+                        items: projectDurationOptions.map((String value) {
+                          return DropdownMenuItem<String>(
+                            value: value,
+                            child: Text(value),
+                          );
+                        }).toList(),
                       ),
-                    ),
-                  const SizedBox(height: 10),
-                  // 알리미 시작하기 또는 없음 버튼
-                  GestureDetector(
-                    onTap: _onTapHandler,
-                    child: Row(
-                      crossAxisAlignment: CrossAxisAlignment.center,
-                      mainAxisAlignment: MainAxisAlignment.end,
-                      children: [
-                        Text(
-                          projectNameController.text.isNotEmpty &&
-                                  projectExperienceController.text.isNotEmpty &&
-                                  githubLinkController.text.isNotEmpty &&
-                                  rollController.text.isNotEmpty &&
-                                  partController.text.isNotEmpty &&
-                                  (selectedDuration != null ||
-                                      customDurationValue.isNotEmpty)
-                              ? (widget.update == true)
-                                  ? '경험 추가하기'
-                                  : '알리미 시작하기'
-                              : '없음',
-                          style: const TextStyle(
-                            fontSize: 16,
-                            fontWeight: FontWeight.bold,
-                            color: Color(0xFF2A72E7),
+                      if (selectedDuration[index] == '직접 입력' &&
+                          customDurationValue[index].isEmpty)
+                        Padding(
+                          padding: const EdgeInsets.symmetric(vertical: 10.0),
+                          child: TextFormField(
+                            onChanged: (value) {
+                              customDurationValue[index] = value;
+                            },
+                            decoration: const InputDecoration(
+                              labelText: '프로젝트 기간을 직접 입력해주세요',
+                              labelStyle: TextStyle(
+                                fontSize: 12,
+                                color: Color(0xFF808080),
+                              ),
+                              border: OutlineInputBorder(
+                                borderSide: BorderSide(
+                                  color: Colors.black,
+                                ),
+                                borderRadius: BorderRadius.all(
+                                  Radius.circular(5.0),
+                                ),
+                              ),
+                              contentPadding: EdgeInsets.symmetric(
+                                  horizontal: 10.0, vertical: 5.0),
+                            ),
+                            style: const TextStyle(
+                              fontSize: 12,
+                            ),
                           ),
                         ),
-                        const Icon(
-                          Icons.chevron_right_rounded,
-                          color: Color(0xFF2A72E7),
-                        ),
-                      ],
+                      // if (customDurationValue
+                      //     .isNotEmpty) // 직접 입력된 기간이 있을 때만 보여줌
+                      //   Padding(
+                      //     padding: const EdgeInsets.symmetric(vertical: 10.0),
+                      //     child: Text(
+                      //       '직접 입력한 프로젝트 기간: $customDurationValue',
+                      //       style: const TextStyle(
+                      //         fontSize: 12,
+                      //         color: Color(0xFF808080),
+                      //       ),
+                      //     ),
+                      //   ),
+                    ],
+                  );
+                },
+                separatorBuilder: (BuildContext context, int index) =>
+                    const Column(
+                  // Divider로 구분
+                  children: [
+                    SizedBox(height: 10),
+                    Divider(),
+                    SizedBox(height: 10),
+                  ],
+                ),
+                itemCount: formatLength,
+              ),
+
+              // 겸험 추가하기 버튼
+              ElevatedButton(
+                onPressed: () {
+                  setState(() {
+                    formatLength++;
+                  });
+                  _addNewExperienceFields();
+                },
+                style: ElevatedButton.styleFrom(
+                  padding: const EdgeInsets.symmetric(vertical: 10),
+                  backgroundColor: Colors.transparent,
+                  elevation: 0,
+                  side: const BorderSide(
+                    color: Colors.blueAccent,
+                  ),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(8.0),
+                  ),
+                ),
+                child: const Center(
+                  child: Text(
+                    '경험 추가하기',
+                    style: TextStyle(
+                      color: Colors.blueAccent,
+                      fontWeight: FontWeight.bold,
+                      fontSize: 16,
                     ),
                   ),
-                ],
+                ),
+              ),
+              const SizedBox(height: 10),
+
+              // 알리미 시작하기 또는 없음 버튼
+              GestureDetector(
+                onTap: _onTapHandler,
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  mainAxisAlignment: MainAxisAlignment.end,
+                  children: [
+                    // 컨트롤러와 String의 첫부분이 작성되지 않으면 알리미 시작하기 버튼으로 표시
+                    Text(
+                      projectNameController[0].text.isNotEmpty &&
+                              projectExperienceController[0].text.isNotEmpty &&
+                              githubLinkController[0].text.isNotEmpty &&
+                              partController[0].text.isNotEmpty &&
+                              (selectedDuration[0] != null ||
+                                  customDurationValue[0].isNotEmpty)
+                          ? (widget.update == true)
+                              ? '경험 추가하기'
+                              : '알리미 시작하기'
+                          : '없음',
+                      style: const TextStyle(
+                        fontSize: 16,
+                        fontWeight: FontWeight.bold,
+                        color: Color(0xFF2A72E7),
+                      ),
+                    ),
+                    const Icon(
+                      Icons.chevron_right_rounded,
+                      color: Color(0xFF2A72E7),
+                    ),
+                  ],
+                ),
               ),
             ],
           ),


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
#252

## ✨ 코드 변경 내용
<!-- 코드 변경에 대한 설명을 적어주세요 -->
### 경험 한개 작성하기 구현
- 경험 작성에 쓰일 컨트롤러와 문자열 변수를 리스트로 생성
- 경험 추가하기 버튼은 통해 add 함수 실행과 formatLength 1 추가
- formatLength 길이로 인해 경험 작성 양식을 ListView.separted를 통해 생성
- 각각 리스트 0번째 값이 비어있지 않으면 경험 추가하기 버튼을 표시, 그렇지 않으면 없음을 표시
### 경험 여러개 작성 api 구현
- 프로젝트명 컨트롤러 리스트 개수에 따라 for문을 돌려 경험 정보들을 저장 후 newExperiecs 리스트에 추가
- 텍스트폼필드에 포커스 색상과 커서 색상을 대표 색상으로 변경
- 경험 조회 화면에서 올 경우에만 경험 추가하기 버튼이 보이게 구현

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
