### PR TITLE
[Feat/#250] 달력에 투표 일정 넣기

### DIFF
--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -17,6 +17,7 @@ import 'package:frontend/screens/login_screen.dart';
 import 'package:frontend/screens/recruitDetail_screen.dart';
 import 'package:get/get.dart';
 import 'package:frontend/services/login_services.dart';
+import 'package:intl/date_symbol_data_local.dart';
 import 'package:provider/provider.dart';
 
 // 알림 플러그인 인스턴스 생성 (로컬 푸시 알림을 보여주기 위한 플러그인)
@@ -73,6 +74,8 @@ final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized(); // Flutter의 비동기적 초기화
+
+  await initializeDateFormatting();
 
   // ByteData data = await PlatformAssetBundle()
   //     .load('assets/ca/star.sungkyul.ac.kr.cert.pem');

--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/services.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';

--- a/frontend/lib/providers/vote_provider.dart
+++ b/frontend/lib/providers/vote_provider.dart
@@ -6,9 +6,11 @@ import 'package:http/http.dart' as http;
 
 class VoteProvider with ChangeNotifier {
   final List<Vote> _voteList = [];
+  final List<Vote> _allVoteList = []; // 전체 투표 조회 API 리스트
   final List<Map<String, dynamic>> _contentList = [];
 
   List<Vote> get voteList => _voteList;
+  List<Vote> get allVoteList => _allVoteList;
   List<Map<String, dynamic>> get contentList => _contentList;
 
   // 엑세스 토큰 할당
@@ -112,6 +114,41 @@ class VoteProvider with ChangeNotifier {
       print('투표 조회 성공: ${Vote.fromJson(dataResponse)} - $dataResponse');
     } else {
       print("투표 조회 실패: ${response.body}");
+    }
+  }
+
+  // 투표 전체 조회
+  Future<void> fetchVotes() async {
+    final accessToken = await getToken();
+    if (accessToken == null) {
+      throw Exception('엑세스 토큰을 찾을 수 없음');
+    }
+
+    final url = Uri.parse(baseUrl);
+    final response = await http.get(
+      url,
+      headers: {
+        'access': accessToken,
+      },
+    );
+    _allVoteList.clear();
+
+    if (response.statusCode == 200) {
+      final utf8Response = utf8.decode(response.bodyBytes);
+      final jsonResponse = json.decode(utf8Response);
+
+      final dataResponse = jsonResponse['data'];
+
+      // dataResponse가 Map일 경우 직접 Vote 객체로 변환하여 추가
+      for (var data in dataResponse) {
+        _allVoteList.add(Vote.fromJson(data));
+      }
+
+      notifyListeners();
+
+      print('투표 전체 조회 성공:$dataResponse');
+    } else {
+      print("투표 전체 조회 실패: ${response.body}");
     }
   }
 

--- a/frontend/lib/screens/boardDetail_screen.dart
+++ b/frontend/lib/screens/boardDetail_screen.dart
@@ -15,6 +15,7 @@ import 'package:frontend/screens/update_screen.dart';
 import 'package:frontend/models/vote_model.dart';
 import 'package:frontend/providers/announcement_provider.dart';
 import 'package:get/get.dart';
+import 'package:intl/intl.dart';
 import 'package:path/path.dart' as path;
 import 'package:frontend/widgets/vote_widget.dart';
 import 'package:frontend/services/login_services.dart';
@@ -81,6 +82,14 @@ class _BoardDetailPageState extends State<BoardDetailPage> {
       userRole = credentials['userRole']; // 로그인 정보에 있는 level를 가져와 저장
       level = credentials['level'];
     });
+  }
+
+  // 국제 표준시간에서 한국시간으로 변환 메서드
+  // 만든 이유: 앱에서 설정한 시간은 한국시간으로 잘 받아지는데 작성 api 성공 후 서버에서 받은 시간에서는 국제 표준 시간으로 받아 만들게 됨
+  String convertUtcToKst(String utcTimeString) {
+    DateTime utcTime = DateTime.parse(utcTimeString);
+    DateTime kstTime = utcTime.add(const Duration(hours: 9));
+    return DateFormat("yyyy-MM-dd HH:mm").format(kstTime);
   }
 
   // Uint8List를 파일로 저장하는 함수
@@ -288,6 +297,16 @@ class _BoardDetailPageState extends State<BoardDetailPage> {
                           child: const Icon(Icons.more_vert),
                         ),
                       ],
+                    ),
+                    const SizedBox(height: 5),
+
+                    // 게시글 생성 시간
+                    Text(
+                      convertUtcToKst(board['createdTime']),
+                      style: const TextStyle(
+                        color: Color(0xFFD9D9D9),
+                        fontSize: 12,
+                      ),
                     ),
                     const SizedBox(height: 20),
 

--- a/frontend/lib/screens/login_screen.dart
+++ b/frontend/lib/screens/login_screen.dart
@@ -211,6 +211,7 @@ class _LoginPageState extends State<LoginPage> {
     await prefs.setString('fcmToken', token); // FCM 토큰 저장
     await prefs.setInt(
         'fcmTokenTimestamp', DateTime.now().millisecondsSinceEpoch); // 발급 시각 저장
+    print('FCM 토큰이 저장되었습니다');
   }
 
 // FCM 토큰을 삭제하는 함수
@@ -221,7 +222,7 @@ class _LoginPageState extends State<LoginPage> {
     print('FCM 토큰이 삭제되었습니다.');
   }
 
-// FCM 토큰 갱신 여부를 확인하고, 필요 시 새 토큰을 발급하고 14일 이상 된 경우 토큰 삭제
+  // FCM 토큰 갱신 여부를 확인하고, 필요 시 새 토큰을 발급하고 1년 이상 된 경우 토큰 삭제
   Future<String?> getFCMTokenWithRefreshCheck() async {
     final prefs = await SharedPreferences.getInstance();
     final storedToken = prefs.getString('fcmToken'); // 저장된 토큰
@@ -229,9 +230,9 @@ class _LoginPageState extends State<LoginPage> {
         prefs.getInt('fcmTokenTimestamp') ?? 0; // 저장된 토큰의 발급 시각
 
     final currentTime = DateTime.now().millisecondsSinceEpoch; // 현재 시간
-    const tokenValidityDuration = 14 * 24 * 60 * 60 * 1000; // 14일 (밀리초 단위)
+    const tokenValidityDuration = 365 * 24 * 60 * 60 * 1000; // 365일 (밀리초 단위)
 
-    // 토큰이 없거나, 14일 이상이 지난 경우 새 토큰 발급
+    // 토큰이 없거나, 1년 이상이 지난 경우 새 토큰 발급
     if (storedToken == null ||
         currentTime - tokenTimestamp > tokenValidityDuration) {
       // 14일 이상 된 토큰은 삭제
@@ -453,7 +454,11 @@ class _LoginPageState extends State<LoginPage> {
                 // 로그인 버튼
                 ElevatedButton(
                   onPressed: () async {
+                    final prefs = await SharedPreferences.getInstance();
                     await _getFCMToken();
+
+                    print(
+                        'FCM 토큰: ${prefs.getString('fcmToken')}, 발급 시각: ${prefs.getInt('fcmTokenTimestamp')}');
 
                     // 유효성 통과 시 홈 화면으로 이동
                     if (formKey.currentState!.validate()) {

--- a/frontend/lib/screens/totalBoard_screen.dart
+++ b/frontend/lib/screens/totalBoard_screen.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:frontend/providers/announcement_provider.dart';
-import 'package:frontend/screens/boardDetail_screen.dart';
 import 'package:frontend/screens/hiddenList_screen.dart';
 import 'package:frontend/screens/write_screen.dart';
 import 'package:frontend/services/login_services.dart';


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
#250

## ✨ 코드 변경 내용
<!-- 코드 변경에 대한 설명을 적어주세요 -->
### 달력에 투표 일정 넣기
- 전체 게시글의 생성 시간과 달력의 날짜와 비교해 동일한 게시글을 selectedBoardList에 저장(추가)
- selectedBoardList가 있으면 showModalBottomSheet 위젯을 통해 투표가 있는 게시글만 투표 표시
- 달력에서 색상 스타일링 구현
### 투표 있는 날에 마커 표시 기능 구현
- 투표 전체 조회 API 구현
- 투표 전체 조회 리스트(voteList) 생성
- voteList와 boardList를 차례로 for문을 돌아 게시글 아이디와 투표의 게시글 아이디가 동일하면 시작시간과 종료시간을 구함
- 시작일 이후와 종료일 이전이면 events에 추가해 반환
### 시작일부터 종료일까지 달력에 일정넣기
- 게시글아이디와 투표의 게시글 아이디가 동일하면 시작과 종료시간을 생성해 년-월-일이 사이에 있으면 달력에 일정 넣기

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->
https://github.com/user-attachments/assets/26141b2a-603d-4a4b-b3d3-1519632144af

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
TableCalendar의 기능들
